### PR TITLE
Multiple paths are tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ let val = any((
 
 echo val.bar.saying #> "goodbye"
 ```
+
+
+### References
+
+Things I read while developing this
+
+- [Functional Parsers by Jeroen Fokker](http://cmsc-16100.cs.uchicago.edu/2017/Lectures/17/parsers.pdf)

--- a/src/nort.nim
+++ b/src/nort.nim
@@ -28,7 +28,7 @@ runnableExamples:
 
   echo name.match("jgod1")
 
-  for line in everything.match(data):
+  for line in everything.match(data).get():
     # Each line has a tuple with the names we binded
     if line.failure.count == 0: # Count was actually parsed as an int!
       echo fmt"{line.name} never failed!"

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -37,21 +37,22 @@ proc bindTo*[T, R](comb: Combinator[Void]) {.error: "Can't attach a variable nam
 template `$`*[T](comb: Combinator[T], name: untyped): untyped =
   bindTo[T, tuple[name: T]](comb)
 
-proc trace*[T](g: Combinator[T]): Combinator[T] =
+proc trace*[T](comb: Combinator[T]): Combinator[T] =
   ## Utility function that echos the result of a combinator
-  return proc (p: var Parser): Option[T] =
-    let start = p.pos
-    result = g(p)
-    if result.isNone:
+  return proc (p: Parser): ParseTree[T] =
+    result = comb(p)
+    if result.len == 0:
       echo "Failed to parse"
     else:
-      echo fmt"Parsed: '{p.data[start ..< p.pos]}'"
-      when T isnot Void:
-        echo fmt"Got: '{result.get()}'"
+      for path in result:
+        echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
+        when T isnot Void:
+            echo fmt"Got: '{path.value}'"
 
 
 # Functions to make Void compose with Chain
 proc add*(coll: var Chain[Void], val: Void) = discard
+proc `&`*(a, b: Void): Void = a
 
 proc match*[T](comb: Combinator[T], data: string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -52,3 +52,36 @@ proc trace*[T](g: Combinator[T]): Combinator[T] =
 
 # Functions to make Void compose with Chain
 proc add*(coll: var Chain[Void], val: Void) = discard
+
+proc match*[T](comb: Combinator[T], data: string): Option[T] =
+  ## Checks if a string matches a pattern. Returns the first match
+  let p = Parser(data: data)
+  for res in comb(p):
+    return res
+
+iterator match*[T](comb: Combinator[T], data: string): T =
+  ## Returns zero or more matches of `comb` in data
+  runnableExamples:
+    # Will echo 3 phrases
+    var count = 0
+    let g = any(e"hi", e"bye")
+    for line in g.match("hibyehi"):
+      count += 1
+      echo line
+    assert count == 3
+
+  var p = Parser(data: data)
+  while true:
+    let ret = comb(p)
+    if ret == @[]: break
+    yield ret.value
+    p = ret.parser
+
+proc test*[T](comb: Combinator[T], data: sink string): bool =
+  ## Tests if an input matches a combinator
+  runnableExamples:
+    let g = e"hello"
+    assert g.test("hello")
+    assert not g.test("bye")
+
+  comb.match(data).isSome()

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -57,7 +57,7 @@ proc match*[T](comb: Combinator[T], data: string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match
   let p = Parser(data: data)
   for res in comb(p):
-    return res
+    return res.value.some()
 
 iterator match*[T](comb: Combinator[T], data: string): T =
   ## Returns zero or more matches of `comb` in data
@@ -85,3 +85,12 @@ proc test*[T](comb: Combinator[T], data: sink string): bool =
     assert not g.test("bye")
 
   comb.match(data).isSome()
+
+proc lazy*[T](comb: proc (): Combinator[T]): Combinator[T] =
+  ## Makes a lazy version of `comb` that is only created when needed.
+  ## Use this when you have recursive grammars
+  var stored: Combinator[T] = nil
+  return proc (p: Parser): ParseTree[T] =
+    if stored == nil:
+      stored = comb()
+    return stored(p)

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -27,10 +27,9 @@ type
     ## - everything else gets joined in a sequence
 
 proc bindTo*[T; R: tuple](comb: Combinator[T]): Combinator[R] =
-  return proc (p: var Parser): Option[(T,)] =
-    let val = comb(p)
-    if val.isSome():
-      return some((val.get(),))
+  return proc (p: Parser): ParseTree[(T,)] =
+    for val in comb(p):
+      result &= (val.parser, (val.value,))
 
 proc bindTo*[T, R](comb: Combinator[Void]) {.error: "Can't attach a variable name to a `Void` combinator".}
 
@@ -60,27 +59,11 @@ proc match*[T](comb: Combinator[T], data: string): Option[T] =
   for res in comb(p):
     return res.value.some()
 
-iterator match*[T](comb: Combinator[T], data: string): T =
-  ## Returns zero or more matches of `comb` in data
-  runnableExamples:
-    # Will echo 3 phrases
-    var count = 0
-    let g = any(e"hi", e"bye")
-    for line in g.match("hibyehi"):
-      count += 1
-      echo line
-    assert count == 3
-
-  var p = Parser(data: data)
-  while true:
-    let ret = comb(p)
-    if ret == @[]: break
-    yield ret.value
-    p = ret.parser
-
 proc test*[T](comb: Combinator[T], data: sink string): bool =
   ## Tests if an input matches a combinator
   runnableExamples:
+    import nort
+
     let g = e"hello"
     assert g.test("hello")
     assert not g.test("bye")
@@ -90,6 +73,19 @@ proc test*[T](comb: Combinator[T], data: sink string): bool =
 proc lazy*[T](comb: proc (): Combinator[T]): Combinator[T] =
   ## Makes a lazy version of `comb` that is only created when needed.
   ## Use this when you have recursive grammars
+  runnableExamples:
+    import nort
+    import std/sugar
+
+    proc paran(): Combinator[int] =
+      ## Combinator that returns the nesting of paranthesis
+      # We need `lazy` here or else it would go into an infinite loop calling itself
+      lazy(paran).between(e'(', e')').map(count => count + 1) | succeed(0)
+
+    let g = paran()
+    assert g.match("(())").get() == 2
+    assert g.match("").get() == 0
+
   var stored: Combinator[T] = nil
   return proc (p: Parser): ParseTree[T] =
     if stored == nil:

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -8,8 +8,17 @@ type
   Void* = object
     ## Internal type for representing a parser that returns nothing
 
-  Combinator*[T] = proc (p: var Parser): Option[T] {.closure.}
-    ## Parser that optionally returns data
+  ParseResult*[T] = tuple[parser: Parser, value: T]
+    ## Single parse result. This should return the remaining data to parse along with
+    ## the value that was returned
+
+  ParseTree*[T] = seq[ParseResult[T]]
+    ## Tree of parsed result values
+
+  Combinator*[T] = proc (p: Parser): ParseTree[T] {.closure.}
+    ## Parser that optionally returns data.
+    ## This returns all possible matches of running the parser
+    # TODO: Make this lazy
 
   Chain*[T] = (when T is char: string elif T is Void: Void else: seq[T])
     ## Represents how types get chained together when using repition like `+` and `*`

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -55,22 +55,28 @@ proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] 
     assert g.test("hello world")
     assert not g.test("world")
 
-  return proc (p: var Parser): Option[T] =
+  return proc (p: Parser): ParseTree[T] =
     comb(p).filter(check)
 
-proc dot*: Combinator[char] =
+proc dot*(): Combinator[char] =
   ## Parses any character
   runnableExamples:
     assert dot().match("abc") == some('a')
-  return parser.eat
 
-proc expect*(expect: set[char]): Combinator[char] =
-  ## Expects a set of characters, returns the matched value
-  runnableExamples:
-    let g = expect({'a', 'b', 'c'})
-    assert g.match("a") == some('a')
-    assert g.match("d").isNone()
-  return filter(eat, it => it in expect)
+  return proc (p: Parser): ParseTree[char] =
+    p.eat().map(c => @[c]).orElse(@[])
+
+proc succeed[T](value: T): Combinator[T] =
+  ## Combinator that always successeds and never comsumes input
+  return proc (p: Parser): ParseTree[T] = @[value]
+
+proc fail(): Combinator[Void] =
+  ## Combinator that matches nothing
+  return proc (p: Parser): ParseTree[Void] = @[]
+
+proc epsilon(): Combinator[Void] =
+  ## Matches the empty string and doesn't return any input
+  return succeed(Void())
 
 proc expect*(input: char): Combinator[char] =
   ## Expects a character to appear
@@ -79,7 +85,15 @@ proc expect*(input: char): Combinator[char] =
     assert g.match("a") == some('a')
     assert g.match("b").isNone()
 
-  return expect({input})
+  return filter(dot(), it => it == input)
+
+proc expect*(expect: set[char]): Combinator[char] =
+  ## Expects a set of characters, returns the matched value
+  runnableExamples:
+    let g = expect({'a', 'b', 'c'})
+    assert g.match("a") == some('a')
+    assert g.match("d").isNone()
+  return filter(dot(), it => it in expect)
 
 proc expect*(expect: string): Combinator[string] =
   ## Expects a certain string
@@ -262,9 +276,9 @@ proc fin*(): Combinator[Void] {.inline.} =
     assert g.test("hello")
     assert not g.test("hello world")
 
-  return proc (p: var Parser): Option[Void] =
-    if p.eof(): some(Void())
-    else: none(Void)
+  return proc (p: Parser): ParseTree[Void] =
+    if p.len == 0: @[Void()]
+    else: @[]
 
 proc any*[T: tuple](options: T): Combinator[mapAny(T)] =
   ## Named branch of what to expect

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -182,20 +182,20 @@ proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combin
     assert res.outcome == "won"
     assert res.score == 9
 
-  return (left <*> right).map(values => join(values.left, values.right, type(result)))
+  (left <*> right).map(values => join(values.left, values.right, type(result)))
 
 proc `*`*[A: tuple, B: not tuple](left: Combinator[A], right: Combinator[B]): Combinator[A] =
   ## Joins two combinators. Only returns the left combinator so named values are carried through
-  return left <* right
+  left <* right
 
 proc `*`*[A: not tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combinator[B] =
   ## Joins two combinators.  Only returns the right combinator so named values are carried through
-  return left *> right
+  left *> right
 
 template `*`*[A, B](left: Combinator[A], right: Combinator[B]): Combinator[Void] =
   ## Joins two combinators. Types are erased since we don't know what to do
   ## with them
-  return -(left <*> right)
+  -(left <*> right)
 
 proc `*`*(left: Combinator[Void], right: Combinator[Void]): Combinator[Void] =
   ## Joins two combinators
@@ -231,18 +231,15 @@ proc `*`*[T](left: Combinator[Chain[T]], right: Combinator[T]): Combinator[Chain
 
 proc any*[T: tuple](options: T): Combinator[mapAny(T)] =
   ## Named branch of what to expect
-  return proc (p: var Parser): Option[result.T] =
+  return proc (p: Parser): ParseTree[result.T] =
     for field, comb in options.fieldPairs:
       block:
-        let init = p.pos
         let res = comb(p)
-        if res.isSome():
+        for path in res:
           var ret = result.T(name: makeIdent(field))
           {.cast(uncheckedAssign).}:
-            access(ret, field) = res.get()
-          return some(ret)
-        else:
-          p.pos = init
+            access(ret, field) = path.value
+          result &= (path.parser, ret)
 
 proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
   ## Passes if any of the combinators pass, this returns the value that passed
@@ -327,7 +324,8 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
     assert g.test("")
     assert g.test("heyhey")
 
-  return (comb <*> (*comb)).map(values => values.left & values.right) | succeed(default(Chain[T]))
+  # The right recursion will make this find the longest match first
+  (comb <*> lazy(() => *comb)).map(values => values.left & values.right) | succeed(default(Chain[T]))
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   ## Expects a combinator to match 1 or more times. Returns all matches
@@ -406,11 +404,6 @@ proc digit*(): Combinator[int] =
     result = values[1].parseInt()
     if values[0]:
       result *= -1
-
-proc rec*[T](body: proc (self: DeferredCombinator[T]): Combinator[T]): Combinator[T] =
-  let def = DeferredCombinator[T](comb: new Combinator[T])
-  def.comb[] = body(def)
-  return def.comb[]
 
 proc map*[R](mapping: openArray[(Combinator[Void], R)]): Combinator[R] =
   ## Maps matching input values to output values

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -1,4 +1,4 @@
-import std/[options, sugar, parseutils, macros, sequtils, enumutils, strutils, setutils, sets]
+import std/[options, sugar, parseutils, macros, sequtils, enumutils, strutils, setutils, sets, sequtils]
 
 export options
 
@@ -56,7 +56,7 @@ proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] 
     assert not g.test("world")
 
   return proc (p: Parser): ParseTree[T] =
-    comb(p).filter(check)
+    comb(p).filter(res => check(res.value))
 
 proc dot*(): Combinator[char] =
   ## Parses any character
@@ -64,11 +64,11 @@ proc dot*(): Combinator[char] =
     assert dot().match("abc") == some('a')
 
   return proc (p: Parser): ParseTree[char] =
-    p.eat().map(c => @[c]).orElse(@[])
+    p.eat().map(c => @[c]).get(@[])
 
 proc succeed[T](value: T): Combinator[T] =
   ## Combinator that always successeds and never comsumes input
-  return proc (p: Parser): ParseTree[T] = @[value]
+  return proc (p: Parser): ParseTree[T] = @[(p, value)]
 
 proc fail(): Combinator[Void] =
   ## Combinator that matches nothing
@@ -102,8 +102,8 @@ proc expect*(expect: string): Combinator[string] =
     assert g.match("foo") == some("foo")
     assert g.match("bar").isNone()
 
-  return proc (p: var Parser): Option[string] =
-    p.continuesWith(expect)
+  return proc (p: Parser): ParseTree[string] =
+    p.continuesWith(expect).map(val => @[val]).get(@[])
 
 proc expect*[T](values: HashSet[T]): Combinator[T] =
   ## Expects a single value from a set of values.
@@ -113,45 +113,67 @@ proc expect*[T](values: HashSet[T]): Combinator[T] =
       expect(value)
   return any(possible)
 
-proc digit*(): Combinator[int] =
-  ## Expects a digit
+proc just*[T](comb: Combinator[T]): Combinator[T] =
+  ## Expects the combinator to fully match the input.
   runnableExamples:
-    assert digit().match("123").get() == 123
-  return proc (p: var Parser): Option[int] =
-    let init = p.pos
-    var res: int
-    p.pos += p.data.parseInt(res, start=init)
+    let g = just(e"hello")
 
-    # If the position progressed, then the parsing was a success
-    if p.pos == init: none(int)
-    else: some(res)
+    assert g.test("hello")
+    assert not g.test("hello world")
+
+  return proc (p: Parser): ParseTree[T] =
+    for res in comb(p):
+      if res.parser.len == 0: # No input left
+        result &= res
+
+# You'll see functions like this that don't need to be functions.
+# It helps with errors if the type system knows its a Combinator, compiler should inline it
+proc fin*(): Combinator[Void] {.inline.} =
+  ## Expects there to be no more data
+  runnableExamples:
+    let g = e"hello" * fin()
+
+    assert g.test("hello")
+    assert not g.test("hello world")
+
+  return proc (p: Parser): ParseTree[Void] =
+    if p.len == 0: @[(p, Void())]
+    else: @[]
+
+proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
+  ## Allows you to perform an operator on a combinators output if it passes
+  runnableExamples:
+    import std/[sugar, strutils]
+
+    let g = "hello".expect.map(toUpperAscii)
+    assert g.match("hello").get() == "HELLO"
+
+  return proc (p: Parser): ParseTree[R] =
+    comb(p).map(res => (res.parser, op(res.value)))
 
 proc `-`*(comb: Combinator): Combinator[Void] =
   ## Erases the type from a combinator
-  return proc (p: var Parser): Option[Void] =
-    if comb(p).isNone(): none(Void)
-    else: some(Void())
+  return comb.map(it => Void())
 
-proc attempt*[T](p: var Parser, comb: Combinator[T]): Option[T] =
-  ## Attempts to run a combinator. Resets the parser if it fails
-  let init = p.pos
-  result = comb(p)
-  if result.isNone():
-    p.pos = init
+proc `<*>`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[left: L, right: R]] =
+  ## Joins two combinators and returns a tuple of both parsed values.
+  ## The [*] series of operators are more user friendly by flattening the returned values
+  return proc (parser: Parser): ParseTree[tuple[left: L, right: R]] =
+    for (newParser, leftValue) in left(parser):
+      for (finalParser, rightValue) in right(newParser):
+        result &= (finalParser, (leftValue, rightValue))
 
-proc prec[L, R, T](p: var Parser, left: Combinator[L], right: Combinator[R], join: proc (l: L, r: R): T): Option[T] =
-  ## Attempts to run `left`, if that successeds then it runs `right`.
-  ## If both pass then it calls `join` to merge them
-  let l = p.attempt(left)
-  if l.isNone: return none(T)
+proc `<*`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =
+  ## Joins two combinators but only retains the left value
+  (left <*> right).map(it => it.left)
 
-  let r = p.attempt(right)
-  if r.isNone: return none(T)
 
-  return some(join(l.get(), r.get()))
+proc `*>`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[R] =
+  ## Joins two combinators but only retains the right value
+  (left <*> right).map(it => it.right)
 
 proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combinator[merge(A, B)] =
-  ## Joins two combinators along with their outputs
+  ## Joins two combinators and merges the tuples together
   runnableExamples:
     let g = any(e"won", e"lost")$outcome * e" " * digit()$score
 
@@ -160,25 +182,20 @@ proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combin
     assert res.outcome == "won"
     assert res.score == 9
 
-  return proc (p: var Parser): Option[merge(A, B)] =
-    p.prec(left, right) do (l: A, r: B) -> merge(A, B):
-      join(l, r, type(result))
+  return (left <*> right).map(values => join(values.left, values.right, type(result)))
 
 proc `*`*[A: tuple, B: not tuple](left: Combinator[A], right: Combinator[B]): Combinator[A] =
-  ## Joins two combinators
-  return proc (p: var Parser): Option[A] =
-    p.prec(left, right) do (l: A, r: B) -> A: l
+  ## Joins two combinators. Only returns the left combinator so named values are carried through
+  return left <* right
 
 proc `*`*[A: not tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combinator[B] =
-  ## Joins two combinators
-  return proc (p: var Parser): Option[B] =
-    p.prec(left, right) do (l: A, r: B) -> B: r
+  ## Joins two combinators.  Only returns the right combinator so named values are carried through
+  return left *> right
 
 template `*`*[A, B](left: Combinator[A], right: Combinator[B]): Combinator[Void] =
   ## Joins two combinators. Types are erased since we don't know what to do
   ## with them
-  proc (p: var Parser): Option[Void] =
-    p.prec(left, right) do (l: left.T, r: right.T) -> Void: Void()
+  return -(left <*> right)
 
 proc `*`*(left: Combinator[Void], right: Combinator[Void]): Combinator[Void] =
   ## Joins two combinators
@@ -186,8 +203,7 @@ proc `*`*(left: Combinator[Void], right: Combinator[Void]): Combinator[Void] =
     let g = e"hello" * e" " * e"world"
     assert g.test("hello world")
 
-  return proc (p: var Parser): Option[Void] =
-    p.prec(left, right) do (l, r: Void) -> Void: Void()
+  return -(left <*> right)
 
 proc `*`*[T: not tuple](left: Combinator[T], right: Combinator[Void]): Combinator[T] =
   ## Carries a type through if the right side doesn't have one
@@ -195,8 +211,7 @@ proc `*`*[T: not tuple](left: Combinator[T], right: Combinator[Void]): Combinato
     let g = e"hello" * e" " * e"world"
     assert g.test("hello world")
 
-  return proc (p: var Parser): Option[T] =
-    p.prec(left, right) do (l: T, r: Void) -> T: l
+  left <* right
 
 proc `*`*[T](left: Combinator[Void], right: Combinator[T]): Combinator[T] =
   ## Carries a type through if the right side doesn't have one
@@ -204,81 +219,15 @@ proc `*`*[T](left: Combinator[Void], right: Combinator[T]): Combinator[T] =
     let g = e"hello" * e" " * e"world"
     assert g.test("hello world")
 
-  return proc (p: var Parser): Option[T] =
-    p.prec(left, right) do (l: Void, r: T) -> T: r
+  left *> right
 
 proc `*`*[T](left: Combinator[T], right: Combinator[Chain[T]]): Combinator[Chain[T]] =
   ## Joins two combinators, merging the results of both
-  return proc (p: var Parser): Option[Chain[T]] =
-    p.prec(left, right) do (l: T, r: Chain[T]) -> Chain[T]: l & r
+  (left <*> right).map(values => values.left & values.right)
 
 proc `*`*[T](left: Combinator[Chain[T]], right: Combinator[T]): Combinator[Chain[T]] =
   ## Joins two combinators, merging the results of both
-  return proc (p: var Parser): Option[Chain[T]] =
-    p.prec(left, right) do (l: Chain[T], r: T) -> Chain[T]: l & r
-
-proc match*[T](comb: Combinator[T], data: string): Option[T] =
-  ## Checks if a string matches a pattern. Returns the matched data
-  var p = Parser(data: data)
-  comb(p)
-
-iterator match*[T](comb: Combinator[seq[T]], data: string): T =
-  ## Returns each line that is matched
-  runnableExamples:
-    # Will echo 3 phrases
-    var count = 0
-    let g = *any(e"hi", e"bye")
-    for line in g.match("hibyehi"):
-      count += 1
-      echo line
-    assert count == 3
-
-  var p = Parser(data: data)
-  let ret: typeof(comb(p)) = comb(p)
-  if ret.isSome():
-    for data in ret.get():
-      yield data
-
-iterator match*[T](comb: Combinator[T], data: string): T =
-  ## Returns zero or more matches of `comb` in data
-  runnableExamples:
-    # Will echo 3 phrases
-    var count = 0
-    let g = any(e"hi", e"bye")
-    for line in g.match("hibyehi"):
-      count += 1
-      echo line
-    assert count == 3
-
-  var p = Parser(data: data)
-  while true:
-    let ret = comb(p)
-    if ret.isNone: break
-    yield ret.get()
-
-proc test*[T](comb: Combinator[T], data: sink string): bool =
-  ## Tests if an input matches a combinator
-  runnableExamples:
-    let g = e"hello"
-    assert g.test("hello")
-    assert not g.test("bye")
-
-  var p = Parser(data: data)
-  comb(p).isSome()
-
-# You'll see functions like this that don't need to be functions.
-# It helps with errors if the type system knows its a Combinator, compiler should inline it
-proc fin*(): Combinator[Void] {.inline.} =
-  ## Expects there to be no more data
-  runnableExamples "-r:off": # Reenable after https://github.com/nim-lang/Nim/issues/25433
-    let g = e"hello" * fin()
-
-    assert g.test("hello")
-    assert not g.test("hello world")
-
-  return proc (p: Parser): ParseTree[Void] =
-    if p.len == 0: @[Void()]
-    else: @[]
+  (left <*> right).map(values => values.left & values.right)
 
 proc any*[T: tuple](options: T): Combinator[mapAny(T)] =
   ## Named branch of what to expect
@@ -302,12 +251,11 @@ proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
     assert g.match("yes").get() == "yes"
     assert g.match("no").get() == "no"
 
+  # Just implemented as the union of all possible values
   let opts = @options
-  return proc (p: var Parser): Option[T] =
-    for opt in opts:
-      let res = p.attempt(opt)
-      if res.isSome():
-        return res
+  return proc (p: Parser): ParseTree[T] =
+    for combinator in opts:
+      result &= combinator(p)
 
 proc `|`*[T](left, right: Combinator[T]): Combinator[T] =
   ## This picks either left or right, returning the value that matches
@@ -331,17 +279,6 @@ proc noop*[T](p: var Parser): Option[Option[T]] =
   ## Combinator that always matches. Since this version is typed,
   ## the data return is `none(T)` (but the parsing does pass)
   return some(none(T))
-
-proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
-  ## Allows you to perform an operator on a combinators output if it passes
-  runnableExamples:
-    import std/[sugar, strutils]
-
-    let g = "hello".expect.map(toUpperAscii)
-    assert g.match("hello").get() == "HELLO"
-
-  return proc (p: var Parser): Option[R] =
-    comb(p).map(op)
 
 proc e*[T](val: T): Combinator[T] =
   ## Alias for [expect]
@@ -369,12 +306,6 @@ proc expect*[T: enum](e: typedesc[T]): Combinator[T] =
       $val
   return expect(possible).map(parseEnum[T])
 
-proc error*(msg: string): Combinator[Void] =
-  ## Throws an error, useful for debugging to see if
-  ## the combinator hits something
-  return proc (p: var Parser): Option[Void] =
-    raise (ref CatchableError)(msg: msg)
-
 proc `not`*(comb: Combinator): Combinator[Void] =
   ## Expects a combinator to not match. This is a negative lookahead that doesn't consume
   ## any input
@@ -383,30 +314,20 @@ proc `not`*(comb: Combinator): Combinator[Void] =
     assert not g.test("hello")
     assert g.test("goodbye")
 
-  return proc (p: var Parser): Option[Void] =
-    let start = p.pos
-    if p.attempt(comb).isSome():
-      p.pos = start # Make sure we reset
-      none(Void)
-    else:
-      some(Void())
+  return proc (p: Parser): ParseTree[Void] =
+    let results = comb(p)
+    if results.len > 0: return @[]
+    else: return @[(p, Void())]
 
 proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   ## Expects a combinator to match zero or more times. Returns all matches
+  ## This is greedy and tries to match the most
   runnableExamples:
     let g = *e"hey"
     assert g.test("")
     assert g.test("heyhey")
 
-  return proc (p: var Parser): Option[Chain[T]] =
-    var found: Chain[T]
-    while true:
-      let res = p.attempt(comb)
-      if res.isSome():
-        found &= res.get()
-      else:
-        break
-    return some(found)
+  return (comb <*> (*comb)).map(values => values.left & values.right) | succeed(newSeq[T]())
 
 proc `*`*(comb: Combinator[char]): Combinator[Chain[char]] =
   ## Optimised version that produces a string instead of a sequence of chars
@@ -440,7 +361,7 @@ proc `?`*[T](comb: Combinator[T]): Combinator[Option[T]] =
     assert g.match("hello").get() == some("hello")
 
   let wrapped = comb.map() do (inp: T) -> Option[T]: some(inp)
-  return any(wrapped, Combinator[Option[T]](noop[T]))
+  return any(wrapped, epsilon().map(it => none(T)))
 
 proc sep*[T](comb: Combinator[T], sep: Combinator): Combinator[seq[T]] =
   ## Matches a zero or more of `comb` that is separate by `sep`
@@ -489,6 +410,17 @@ proc occurs*[T](comb: Combinator[T]): Combinator[bool] =
     assert not g.match("100").get().semicolon
 
   (?comb).map(it => it.isSome)
+
+proc digit*(): Combinator[int] =
+  ## Expects a digit
+  runnableExamples:
+    assert digit().match("123").get() == 123
+    assert digit().match("-123").get() == -123
+
+  (e('-').occurs() <*> +e({'0'..'9'})).map() do (values: (bool, string)) -> int:
+    result = values[1].parseInt()
+    if values[0]:
+      result *= -1
 
 proc map*[R](mapping: openArray[(Combinator[Void], R)]): Combinator[R] =
   ## Maps matching input values to output values

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -272,11 +272,6 @@ proc `|`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[Void] =
 
   any(-left, -right)
 
-proc noop*[T](p: var Parser): Option[Option[T]] =
-  ## Combinator that always matches. Since this version is typed,
-  ## the data return is `none(T)` (but the parsing does pass)
-  return some(none(T))
-
 proc e*[T](val: T): Combinator[T] =
   ## Alias for [expect]
   return expect(val)

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -66,11 +66,11 @@ proc dot*(): Combinator[char] =
   return proc (p: Parser): ParseTree[char] =
     p.eat().map(c => @[c]).get(@[])
 
-proc succeed[T](value: T): Combinator[T] =
+proc succeed*[T](value: T): Combinator[T] =
   ## Combinator that always successeds and never comsumes input
   return proc (p: Parser): ParseTree[T] = @[(p, value)]
 
-proc fail(): Combinator[Void] =
+proc failure*(): Combinator[Void] =
   ## Combinator that matches nothing
   return proc (p: Parser): ParseTree[Void] = @[]
 
@@ -155,7 +155,7 @@ proc `-`*(comb: Combinator): Combinator[Void] =
   ## Erases the type from a combinator
   return comb.map(it => Void())
 
-proc `<*>`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[left: L, right: R]] =
+proc `<*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[left: L, right: R]] =
   ## Joins two combinators and returns a tuple of both parsed values.
   ## The [*] series of operators are more user friendly by flattening the returned values
   return proc (parser: Parser): ParseTree[tuple[left: L, right: R]] =
@@ -163,12 +163,12 @@ proc `<*>`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[le
       for (finalParser, rightValue) in right(newParser):
         result &= (finalParser, (leftValue, rightValue))
 
-proc `<*`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =
+proc `<*`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =
   ## Joins two combinators but only retains the left value
   (left <*> right).map(it => it.left)
 
 
-proc `*>`[L, R](left: Combinator[L], right: Combinator[R]): Combinator[R] =
+proc `*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[R] =
   ## Joins two combinators but only retains the right value
   (left <*> right).map(it => it.right)
 
@@ -327,22 +327,7 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
     assert g.test("")
     assert g.test("heyhey")
 
-  return (comb <*> (*comb)).map(values => values.left & values.right) | succeed(newSeq[T]())
-
-proc `*`*(comb: Combinator[char]): Combinator[Chain[char]] =
-  ## Optimised version that produces a string instead of a sequence of chars
-  runnableExamples:
-    let g = *e'a'
-    assert g.match("aaaaa").get() == "aaaaa"
-    assert g.match("").get() == ""
-
-  return proc (p: var Parser): Option[string] =
-    let start = p.pos
-    while p.attempt(comb).isSome():
-      discard
-
-    # Copy it instead of joining each character
-    some(p.data[start ..< p.pos])
+  return (comb <*> (*comb)).map(values => values.left & values.right) | succeed(default(Chain[T]))
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   ## Expects a combinator to match 1 or more times. Returns all matches
@@ -421,6 +406,11 @@ proc digit*(): Combinator[int] =
     result = values[1].parseInt()
     if values[0]:
       result *= -1
+
+proc rec*[T](body: proc (self: DeferredCombinator[T]): Combinator[T]): Combinator[T] =
+  let def = DeferredCombinator[T](comb: new Combinator[T])
+  def.comb[] = body(def)
+  return def.comb[]
 
 proc map*[R](mapping: openArray[(Combinator[Void], R)]): Combinator[R] =
   ## Maps matching input values to output values

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -182,7 +182,7 @@ proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combin
     assert res.outcome == "won"
     assert res.score == 9
 
-  (left <*> right).map(values => join(values.left, values.right, type(result)))
+  (left <*> right).map(values => join(values.left, values.right, type(merge(A, B))))
 
 proc `*`*[A: tuple, B: not tuple](left: Combinator[A], right: Combinator[B]): Combinator[A] =
   ## Joins two combinators. Only returns the left combinator so named values are carried through
@@ -416,7 +416,7 @@ proc map*[R](mapping: openArray[(Combinator[Void], R)]): Combinator[R] =
     assert g.match("Goodbye").get() == Goodbye
 
   let mapping = @mapping
-  return proc (parser: var Parser): Option[R] =
+  return proc (parser: Parser): ParseTree[R] =
     for (gram, ret) in mapping:
-      if parser.gram().isSome():
-        return some(ret)
+      for res in (gram *> succeed(ret))(parser):
+        result &= res

--- a/src/nort/parser.nim
+++ b/src/nort/parser.nim
@@ -1,29 +1,38 @@
 ## Contains basic parsing code. This can be reused for writing your own combinators
 
-import std/[options, parseutils]
+import std/[options, parseutils, sugar]
 
 type
   Parser* = object
-    data*: string
-    pos*: int
+    ## Represents the base parser for stepping through a stream.
+    ## Used to represent a slice without needing to copy everything
+    data*: string # TODO: Ensure this is copy-on-write or else we'll explode
+    pos*: int ## Current position inside `data`
+
+func len*(p: Parser): int =
+  ## Returns the length of remaining data
+  return p.data.len - p.pos
 
 func eof*(p: Parser): bool =
   ## Checks if the parser is at the end of the data
-  return p.pos >= p.data.len
+  return p.len == 0
 
 func peek*(p: Parser): Option[char] =
   ## Returns next character (if not eof). Does not use input
   if p.eof: none(char)
   else: some p.data[p.pos]
 
-func eat*(p: var Parser): Option[char] =
-  ## Returns next character and also consumes input
-  result = p.peek()
-  p.pos += 1
+func skip*(p: Parser, n: int): Parser =
+  ## Skips the parser by `n` characters
+  return Parser(data: p.data, pos: p.pos + n)
 
-func continuesWith*(p: var Parser, token: string): Option[string] =
+func eat*(p: Parser): Option[(Parser, char)] =
+  ## Attempts to grab the next character and return rest of data
+  p.peek().map(c => (p.skip(1), c))
+
+func continuesWith*(p: Parser, token: string): Option[(Parser, string)] =
   ## Checks if the parser continues with a string
   let init = p.pos
   p.pos += p.data.skip(token, start = p.pos)
   if p.pos == init: none(string)
-  else: some(token)
+  else: some((p.skip(token.len), token))

--- a/src/nort/parser.nim
+++ b/src/nort/parser.nim
@@ -32,7 +32,6 @@ func eat*(p: Parser): Option[(Parser, char)] =
 
 func continuesWith*(p: Parser, token: string): Option[(Parser, string)] =
   ## Checks if the parser continues with a string
-  let init = p.pos
-  p.pos += p.data.skip(token, start = p.pos)
-  if p.pos == init: none(string)
-  else: some((p.skip(token.len), token))
+  let matched = p.data.skip(token, start = p.pos)
+  if matched == 0: none((Parser, string))
+  else: some((p.skip(matched), token))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -78,6 +78,14 @@ test "fin matches end of string":
     "hello": true
   }
 
+test "Ambigious grammar works":
+  let g = e('a') * *e({'a', 'b'}) * e("ba") * fin()
+  g.check {
+    "aba": true,
+    "aaaabbbabababbababababa": true,
+    "ba": false
+  }
+
 
 test "Can match union":
   let init: Combinator[Chain[char]] = any(e("hello"), e("goodbye"))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -3,23 +3,7 @@ import std/[unittest, strutils]
 import nort
 import nort/base
 
-template check(comb: Combinator, tests: openArray[(string, bool)]) =
-  ## Runs a series of checks
-  for (input, expected) in tests:
-    let matched = comb.test(input)
-    if matched != expected:
-      checkpoint input
-    check matched == expected
-
-template check[T](comb: Combinator[T], tests: openArray[(string, T)]) =
-  ## Runs a series of checks
-  for (input, expected) in tests:
-    let matched = comb.match(input)
-    if matched.isNone() or matched.get() != expected:
-      checkpoint input
-
-    check matched.isSome()
-    check matched.get() == expected
+import ./utils
 
 test "Can match digit":
   let g = digit()

--- a/tests/testParan.nim
+++ b/tests/testParan.nim
@@ -1,0 +1,40 @@
+## One of the examples from the paper. Whether we can parse paranthesis
+## This tests recursive parsers
+
+import nort
+import std/[sugar, unittest]
+import ./utils
+
+type
+  Tree = ref object
+    case hasVal: bool
+    of true: limbs: tuple[left: Tree, right: Tree]
+    of false: discard
+
+func tree(inp: tuple[left: Tree, right: Tree]): Tree =
+  Tree(hasVal: true, limbs: inp)
+
+func tree(): Tree = Tree(hasVal: false)
+
+proc `$`(x: Tree): string =
+  if x.hasVal:
+    result = "(" & $x.limbs.left & ")" & $x.limbs.right
+  else:
+    result = ""
+
+let
+  open = e'('
+  close = e')'
+
+proc paran(): Combinator[Tree] =
+  ((open *> lazy(paran) <* close) <*> lazy(paran)).map(tree) |
+  succeed(tree())
+
+test "Paranthesis example":
+  paran().just().check {
+    "": true,
+    "()": true,
+    "()()": true,
+    "(())": true,
+    "(()": false
+  }

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -1,0 +1,21 @@
+import nort
+import nort/base
+import std/unittest
+
+template check*(comb: Combinator, tests: openArray[(string, bool)]) =
+  ## Runs a series of checks
+  for (input, expected) in tests:
+    let matched = comb.test(input)
+    if matched != expected:
+      checkpoint input
+    check matched == expected
+
+template check*[T](comb: Combinator[T], tests: openArray[(string, T)]) =
+  ## Runs a series of checks
+  for (input, expected) in tests:
+    let matched = comb.match(input)
+    if matched.isNone() or matched.get() != expected:
+      checkpoint input
+
+    check matched.isSome()
+    check matched.get() == expected


### PR DESCRIPTION
Before a grammar like

```nim
e('a') * *e({'a', 'b'}) * e("ba") * fin()
```

Would fail to match anything since the `*e({'a', 'b'})` would eat all the "b" and "a" characters before the final rule.
I followed the paper "Functional Parsers" and now we return all possible matches instead of just the first match. This lead to the code composing a lot better.

Still need to make it lazy so that we aren't evaluating the entire search tree, but will do that in a future PR