### PR TITLE
Lazy evaluation

### DIFF
--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -22,7 +22,7 @@ type
     ## Parser that optionally returns data.
     ## This returns all possible matches of running the parser in a lazy manner
     iter: proc(): Explorer[T]
-      ## Internal interator that yields matches
+      ## Factory that produces an iterator with all the paths
   Chain*[T] = (when T is char: string elif T is Void: Void else: seq[T])
     ## Represents how types get chained together when using repition like `+` and `*`
     ## - `char` becomes a `string`
@@ -31,13 +31,12 @@ type
 
 iterator results*[T](comb: Combinator[T], parser: Parser): ParseResult[T] =
   ## Yields all the iteration results of a combinator
-  echo comb.iter().finished
   for item in comb.iter()(parser):
     yield item
 
-template initCombinator*[T](explorer: Explorer[T]): Combinator[T] =
+proc initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
   ## Builds a combinator from an iterator
-  Combinator[T](iter: () => explorer)
+  Combinator[T](iter: factory)
 
 proc bindTo*[T; R: tuple](comb: Combinator[T]): Combinator[R] =
   return proc (p: Parser): ParseTree[(T,)] =
@@ -51,16 +50,18 @@ template `$`*[T](comb: Combinator[T], name: untyped): untyped =
 
 proc trace*[T](comb: Combinator[T]): Combinator[T] =
   ## Utility function that echos the result of a combinator
-  return iterator (p: Parser): ParseResult[T] {.closure.} =
-    var foundSomething = false
-    for path in comb.results(p):
-      foundSomething = true
-      echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
-      when T isnot Void:
-          echo fmt"Got: '{path.value}'"
-      yield path
-    if not foundSomething:
-      echo "Failed to parse"
+  return initCombinator(proc (): Explorer[T] =
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      var foundSomething = false
+      for path in comb.results(p):
+        foundSomething = true
+        echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
+        when T isnot Void:
+            echo fmt"Got: '{path.value}'"
+        yield path
+      if not foundSomething:
+        echo "Failed to parse"
+  )
 
 # Functions to make Void compose with Chain
 proc add*(coll: var Chain[Void], val: Void) = discard
@@ -99,7 +100,7 @@ proc lazy*[T](comb: proc (): Combinator[T]): Combinator[T] =
     assert g.match("(())").get() == 2
     assert g.match("").get() == 0
 
-  return initCombinator(
+  return initCombinator(proc (): Explorer[T] =
     iterator (p: Parser): ParseResult[T] {.closure.} =
       yieldfrom comb().results(p)
   )

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -1,8 +1,8 @@
 ## This is internal library code to set everything up
-import std/[options, macros, strformat]
+import std/[options, macros, strformat, sugar]
 export options
 
-import ./parser
+import ./[parser, utils]
 
 type
   Void* = object
@@ -15,16 +15,29 @@ type
   ParseTree*[T] = seq[ParseResult[T]]
     ## Tree of parsed result values
 
-  Combinator*[T] = proc (p: Parser): ParseTree[T] {.closure.}
-    ## Parser that optionally returns data.
-    ## This returns all possible matches of running the parser
-    # TODO: Make this lazy
+  Explorer*[T] = iterator (p: Parser): ParseResult[T] {.closure.}
+    ## Iterator that returns all the paths a parser can take
 
+  Combinator*[T] = object
+    ## Parser that optionally returns data.
+    ## This returns all possible matches of running the parser in a lazy manner
+    iter: proc(): Explorer[T]
+      ## Internal interator that yields matches
   Chain*[T] = (when T is char: string elif T is Void: Void else: seq[T])
     ## Represents how types get chained together when using repition like `+` and `*`
     ## - `char` becomes a `string`
     ## - `Void` stays `Void`, it doesn't make sense to join these
     ## - everything else gets joined in a sequence
+
+iterator results*[T](comb: Combinator[T], parser: Parser): ParseResult[T] =
+  ## Yields all the iteration results of a combinator
+  echo comb.iter().finished
+  for item in comb.iter()(parser):
+    yield item
+
+template initCombinator*[T](explorer: Explorer[T]): Combinator[T] =
+  ## Builds a combinator from an iterator
+  Combinator[T](iter: () => explorer)
 
 proc bindTo*[T; R: tuple](comb: Combinator[T]): Combinator[R] =
   return proc (p: Parser): ParseTree[(T,)] =
@@ -38,16 +51,16 @@ template `$`*[T](comb: Combinator[T], name: untyped): untyped =
 
 proc trace*[T](comb: Combinator[T]): Combinator[T] =
   ## Utility function that echos the result of a combinator
-  return proc (p: Parser): ParseTree[T] =
-    result = comb(p)
-    if result.len == 0:
+  return iterator (p: Parser): ParseResult[T] {.closure.} =
+    var foundSomething = false
+    for path in comb.results(p):
+      foundSomething = true
+      echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
+      when T isnot Void:
+          echo fmt"Got: '{path.value}'"
+      yield path
+    if not foundSomething:
       echo "Failed to parse"
-    else:
-      for path in result:
-        echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
-        when T isnot Void:
-            echo fmt"Got: '{path.value}'"
-
 
 # Functions to make Void compose with Chain
 proc add*(coll: var Chain[Void], val: Void) = discard
@@ -56,7 +69,7 @@ proc `&`*(a, b: Void): Void = a
 proc match*[T](comb: Combinator[T], data: string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match
   let p = Parser(data: data)
-  for res in comb(p):
+  for res in comb.results(p):
     return res.value.some()
 
 proc test*[T](comb: Combinator[T], data: sink string): bool =
@@ -86,8 +99,7 @@ proc lazy*[T](comb: proc (): Combinator[T]): Combinator[T] =
     assert g.match("(())").get() == 2
     assert g.match("").get() == 0
 
-  var stored: Combinator[T] = nil
-  return proc (p: Parser): ParseTree[T] =
-    if stored == nil:
-      stored = comb()
-    return stored(p)
+  return initCombinator(
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      yieldfrom comb().results(p)
+  )

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -40,9 +40,11 @@ proc initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
   Combinator[T](iter: factory)
 
 proc bindTo*[T; R: tuple](comb: Combinator[T]): Combinator[R] =
-  return proc (p: Parser): ParseTree[(T,)] =
-    for val in comb(p):
-      result &= (val.parser, (val.value,))
+  return initCombinator(proc (): Explorer[R] =
+    iterator (p: Parser): ParseResult[(T,)] {.closure.} =
+      for val in comb.results(p):
+        yield (val.parser, (val.value,))
+  )
 
 proc bindTo*[T, R](comb: Combinator[Void]) {.error: "Can't attach a variable name to a `Void` combinator".}
 

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -31,7 +31,8 @@ type
 
 iterator results*[T](comb: Combinator[T], parser: Parser): ParseResult[T] =
   ## Yields all the iteration results of a combinator
-  for item in comb.iter()(parser):
+  let iter = comb.iter()
+  for item in iter(parser):
     yield item
 
 proc initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -55,24 +55,29 @@ proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] 
     assert g.test("hello world")
     assert not g.test("world")
 
-  return proc (p: Parser): ParseTree[T] =
-    comb(p).filter(res => check(res.value))
+  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
+    for res in comb.results(p):
+      if check(res.value):
+        yield res)
 
 proc dot*(): Combinator[char] =
   ## Parses any character
   runnableExamples:
     assert dot().match("abc") == some('a')
 
-  return proc (p: Parser): ParseTree[char] =
-    p.eat().map(c => @[c]).get(@[])
+  return initCombinator(iterator (p: Parser): ParseResult[char] {.closure.} =
+    let res = p.eat()
+    if res.isSome:
+      yield res.get()
+  )
 
 proc succeed*[T](value: T): Combinator[T] =
   ## Combinator that always successeds and never comsumes input
-  return proc (p: Parser): ParseTree[T] = @[(p, value)]
+  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} = yield (p, value))
 
 proc failure*(): Combinator[Void] =
   ## Combinator that matches nothing
-  return proc (p: Parser): ParseTree[Void] = @[]
+  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.} = discard)
 
 proc epsilon(): Combinator[Void] =
   ## Matches the empty string and doesn't return any input
@@ -102,8 +107,10 @@ proc expect*(expect: string): Combinator[string] =
     assert g.match("foo") == some("foo")
     assert g.match("bar").isNone()
 
-  return proc (p: Parser): ParseTree[string] =
-    p.continuesWith(expect).map(val => @[val]).get(@[])
+  return initCombinator(iterator (p: Parser): ParseResult[string] {.closure.} =
+    let res = p.continuesWith(expect)
+    if res.isSome():
+      yield res.get())
 
 proc expect*[T](values: HashSet[T]): Combinator[T] =
   ## Expects a single value from a set of values.
@@ -121,10 +128,10 @@ proc just*[T](comb: Combinator[T]): Combinator[T] =
     assert g.test("hello")
     assert not g.test("hello world")
 
-  return proc (p: Parser): ParseTree[T] =
-    for res in comb(p):
+  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
+    for res in comb.results(p):
       if res.parser.len == 0: # No input left
-        result &= res
+        yield res)
 
 # You'll see functions like this that don't need to be functions.
 # It helps with errors if the type system knows its a Combinator, compiler should inline it
@@ -136,9 +143,9 @@ proc fin*(): Combinator[Void] {.inline.} =
     assert g.test("hello")
     assert not g.test("hello world")
 
-  return proc (p: Parser): ParseTree[Void] =
-    if p.len == 0: @[(p, Void())]
-    else: @[]
+  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.}=
+    if p.len == 0:
+      yield (p, Void()))
 
 proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
   ## Allows you to perform an operator on a combinators output if it passes
@@ -148,8 +155,9 @@ proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
     let g = "hello".expect.map(toUpperAscii)
     assert g.match("hello").get() == "HELLO"
 
-  return proc (p: Parser): ParseTree[R] =
-    comb(p).map(res => (res.parser, op(res.value)))
+  return initCombinator(iterator (p: Parser): ParseResult[R] {.closure.} =
+    for res in comb.results(p):
+      yield (res.parser, op(res.value)))
 
 proc `-`*(comb: Combinator): Combinator[Void] =
   ## Erases the type from a combinator
@@ -158,10 +166,11 @@ proc `-`*(comb: Combinator): Combinator[Void] =
 proc `<*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[left: L, right: R]] =
   ## Joins two combinators and returns a tuple of both parsed values.
   ## The [*] series of operators are more user friendly by flattening the returned values
-  return proc (parser: Parser): ParseTree[tuple[left: L, right: R]] =
-    for (newParser, leftValue) in left(parser):
-      for (finalParser, rightValue) in right(newParser):
-        result &= (finalParser, (leftValue, rightValue))
+  return initCombinator(iterator (parser: Parser): ParseResult[tuple[left: L, right: R]] {.closure.} =
+    for (newParser, leftValue) in left.results(parser):
+      for (finalParser, rightValue) in right.results(newParser):
+        yield (finalParser, (leftValue, rightValue))
+  )
 
 proc `<*`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =
   ## Joins two combinators but only retains the left value
@@ -231,15 +240,15 @@ proc `*`*[T](left: Combinator[Chain[T]], right: Combinator[T]): Combinator[Chain
 
 proc any*[T: tuple](options: T): Combinator[mapAny(T)] =
   ## Named branch of what to expect
-  return proc (p: Parser): ParseTree[result.T] =
+  return initCombinator(iterator (p: Parser): ParseResult[result.T] {.closure.} =
     for field, comb in options.fieldPairs:
       block:
-        let res = comb(p)
-        for path in res:
+        for path in comb(p):
           var ret = result.T(name: makeIdent(field))
           {.cast(uncheckedAssign).}:
             access(ret, field) = path.value
-          result &= (path.parser, ret)
+          yield (path.parser, ret)
+  )
 
 proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
   ## Passes if any of the combinators pass, this returns the value that passed
@@ -250,9 +259,10 @@ proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
 
   # Just implemented as the union of all possible values
   let opts = @options
-  return proc (p: Parser): ParseTree[T] =
+  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
     for combinator in opts:
-      result &= combinator(p)
+      yieldfrom combinator.results(p)
+  )
 
 proc `|`*[T](left, right: Combinator[T]): Combinator[T] =
   ## This picks either left or right, returning the value that matches
@@ -274,11 +284,11 @@ proc `|`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[Void] =
 
 proc e*[T](val: T): Combinator[T] =
   ## Alias for [expect]
-  return expect(val)
+  expect(val)
 
 proc e*[T](val: set[T]): Combinator[T] =
   ## Alias for [expect], expect for sets we expect the single match to return
-  return expect(val)
+  expect(val)
 
 proc expect*[T: enum](e: typedesc[T]): Combinator[T] =
   ## Expects to read an enum. This is based on the stringified value of the enum
@@ -296,7 +306,7 @@ proc expect*[T: enum](e: typedesc[T]): Combinator[T] =
   const possible = toHashSet do: collect:
     for val in fullset(e):
       $val
-  return expect(possible).map(parseEnum[T])
+  expect(possible).map(parseEnum[T])
 
 proc `not`*(comb: Combinator): Combinator[Void] =
   ## Expects a combinator to not match. This is a negative lookahead that doesn't consume
@@ -306,10 +316,11 @@ proc `not`*(comb: Combinator): Combinator[Void] =
     assert not g.test("hello")
     assert g.test("goodbye")
 
-  return proc (p: Parser): ParseTree[Void] =
-    let results = comb(p)
-    if results.len > 0: return @[]
-    else: return @[(p, Void())]
+  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.} =
+    for item in comb(p):
+      return # Something was found, means we don't match
+    yield (p, Void())
+  )
 
 proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   ## Expects a combinator to match zero or more times. Returns all matches
@@ -329,7 +340,7 @@ proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
     assert g.test("hey")
     assert not g.test("")
 
-  return comb * *comb
+  comb * *comb
 
 proc `?`*[T](comb: Combinator[T]): Combinator[Option[T]] =
   ## Optionally matches a combinator. Attempts to parse it first, but will continue without using input if fails
@@ -339,7 +350,7 @@ proc `?`*[T](comb: Combinator[T]): Combinator[Option[T]] =
     assert g.match("hello").get() == some("hello")
 
   let wrapped = comb.map() do (inp: T) -> Option[T]: some(inp)
-  return any(wrapped, epsilon().map(it => none(T)))
+  any(wrapped, epsilon().map(it => none(T)))
 
 proc sep*[T](comb: Combinator[T], sep: Combinator): Combinator[seq[T]] =
   ## Matches a zero or more of `comb` that is separate by `sep`
@@ -348,7 +359,7 @@ proc sep*[T](comb: Combinator[T], sep: Combinator): Combinator[seq[T]] =
     assert g.match("1, 2, 3").get() == @[1, 2, 3]
 
   # We need to convert it to a tuple and then unwrap it or else we lose the types
-  return * (comb * -(?sep))
+  *(comb <* ?sep)
 
 proc until*[T](comb: Combinator[T], target: Combinator): Combinator[Chain[T]] =
   ## Parses `comb` until it encounters `target` (without consuming target)
@@ -416,7 +427,4 @@ proc map*[R](mapping: openArray[(Combinator[Void], R)]): Combinator[R] =
     assert g.match("Goodbye").get() == Goodbye
 
   let mapping = @mapping
-  return proc (parser: Parser): ParseTree[R] =
-    for (gram, ret) in mapping:
-      for res in (gram *> succeed(ret))(parser):
-        result &= res
+  return any(mapping.mapIt(it[0] *> succeed(it[1])))

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -55,29 +55,38 @@ proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] 
     assert g.test("hello world")
     assert not g.test("world")
 
-  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
-    for res in comb.results(p):
-      if check(res.value):
-        yield res)
+  return initCombinator(proc (): Explorer[T] =
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      for res in comb.results(p):
+        if check(res.value):
+          yield res
+  )
 
 proc dot*(): Combinator[char] =
   ## Parses any character
   runnableExamples:
     assert dot().match("abc") == some('a')
 
-  return initCombinator(iterator (p: Parser): ParseResult[char] {.closure.} =
-    let res = p.eat()
-    if res.isSome:
-      yield res.get()
+  return initCombinator(proc (): Explorer[char] =
+    iterator (p: Parser): ParseResult[char] {.closure.} =
+      let res = p.eat()
+      if res.isSome:
+        yield res.get()
   )
 
 proc succeed*[T](value: T): Combinator[T] =
   ## Combinator that always successeds and never comsumes input
-  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} = yield (p, value))
+  return initCombinator(proc (): Explorer[T] =
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      yield (p, value)
+  )
 
 proc failure*(): Combinator[Void] =
   ## Combinator that matches nothing
-  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.} = discard)
+  return initCombinator(proc (): Explorer[Void] =
+    iterator (p: Parser): ParseResult[Void] {.closure.} =
+      discard
+  )
 
 proc epsilon(): Combinator[Void] =
   ## Matches the empty string and doesn't return any input
@@ -107,10 +116,12 @@ proc expect*(expect: string): Combinator[string] =
     assert g.match("foo") == some("foo")
     assert g.match("bar").isNone()
 
-  return initCombinator(iterator (p: Parser): ParseResult[string] {.closure.} =
-    let res = p.continuesWith(expect)
-    if res.isSome():
-      yield res.get())
+  return initCombinator(proc (): Explorer[string] =
+    iterator (p: Parser): ParseResult[string] {.closure.} =
+      let res = p.continuesWith(expect)
+      if res.isSome():
+        yield res.get()
+  )
 
 proc expect*[T](values: HashSet[T]): Combinator[T] =
   ## Expects a single value from a set of values.
@@ -128,10 +139,12 @@ proc just*[T](comb: Combinator[T]): Combinator[T] =
     assert g.test("hello")
     assert not g.test("hello world")
 
-  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
-    for res in comb.results(p):
-      if res.parser.len == 0: # No input left
-        yield res)
+  return initCombinator(proc (): Explorer[T] =
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      for res in comb.results(p):
+        if res.parser.len == 0: # No input left
+          yield res
+  )
 
 # You'll see functions like this that don't need to be functions.
 # It helps with errors if the type system knows its a Combinator, compiler should inline it
@@ -143,9 +156,11 @@ proc fin*(): Combinator[Void] {.inline.} =
     assert g.test("hello")
     assert not g.test("hello world")
 
-  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.}=
-    if p.len == 0:
-      yield (p, Void()))
+  return initCombinator(proc (): Explorer[Void] =
+    iterator (p: Parser): ParseResult[Void] {.closure.}=
+      if p.len == 0:
+        yield (p, Void())
+  )
 
 proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
   ## Allows you to perform an operator on a combinators output if it passes
@@ -155,9 +170,11 @@ proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
     let g = "hello".expect.map(toUpperAscii)
     assert g.match("hello").get() == "HELLO"
 
-  return initCombinator(iterator (p: Parser): ParseResult[R] {.closure.} =
-    for res in comb.results(p):
-      yield (res.parser, op(res.value)))
+  return initCombinator(proc (): Explorer[R] =
+    iterator (p: Parser): ParseResult[R] {.closure.} =
+      for res in comb.results(p):
+        yield (res.parser, op(res.value))
+    )
 
 proc `-`*(comb: Combinator): Combinator[Void] =
   ## Erases the type from a combinator
@@ -166,10 +183,11 @@ proc `-`*(comb: Combinator): Combinator[Void] =
 proc `<*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[left: L, right: R]] =
   ## Joins two combinators and returns a tuple of both parsed values.
   ## The [*] series of operators are more user friendly by flattening the returned values
-  return initCombinator(iterator (parser: Parser): ParseResult[tuple[left: L, right: R]] {.closure.} =
-    for (newParser, leftValue) in left.results(parser):
-      for (finalParser, rightValue) in right.results(newParser):
-        yield (finalParser, (leftValue, rightValue))
+  return initCombinator(proc (): Explorer[tuple[left: L, right: R]] =
+    iterator (parser: Parser): ParseResult[tuple[left: L, right: R]] {.closure.} =
+      for (newParser, leftValue) in left.results(parser):
+        for (finalParser, rightValue) in right.results(newParser):
+          yield (finalParser, (leftValue, rightValue))
   )
 
 proc `<*`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =
@@ -240,14 +258,16 @@ proc `*`*[T](left: Combinator[Chain[T]], right: Combinator[T]): Combinator[Chain
 
 proc any*[T: tuple](options: T): Combinator[mapAny(T)] =
   ## Named branch of what to expect
-  return initCombinator(iterator (p: Parser): ParseResult[result.T] {.closure.} =
-    for field, comb in options.fieldPairs:
-      block:
-        for path in comb(p):
-          var ret = result.T(name: makeIdent(field))
-          {.cast(uncheckedAssign).}:
-            access(ret, field) = path.value
-          yield (path.parser, ret)
+  type Ret = result.T
+  return initCombinator(proc (): Explorer[Ret] =
+    iterator (p: Parser): ParseResult[Ret] {.closure.} =
+      for field, comb in options.fieldPairs:
+        block:
+          for path in comb.results(p):
+            var ret = result.T(name: makeIdent(field))
+            {.cast(uncheckedAssign).}:
+              access(ret, field) = path.value
+            yield (path.parser, ret)
   )
 
 proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
@@ -259,9 +279,10 @@ proc any*[T](options: varargs[Combinator[T]]): Combinator[T] =
 
   # Just implemented as the union of all possible values
   let opts = @options
-  return initCombinator(iterator (p: Parser): ParseResult[T] {.closure.} =
-    for combinator in opts:
-      yieldfrom combinator.results(p)
+  return initCombinator(proc (): Explorer[T] =
+    iterator (p: Parser): ParseResult[T] {.closure.} =
+      for combinator in opts:
+        yieldfrom combinator.results(p)
   )
 
 proc `|`*[T](left, right: Combinator[T]): Combinator[T] =
@@ -316,10 +337,11 @@ proc `not`*(comb: Combinator): Combinator[Void] =
     assert not g.test("hello")
     assert g.test("goodbye")
 
-  return initCombinator(iterator (p: Parser): ParseResult[Void] {.closure.} =
-    for item in comb(p):
-      return # Something was found, means we don't match
-    yield (p, Void())
+  return initCombinator(proc (): Explorer[Void] =
+    iterator (p: Parser): ParseResult[Void] {.closure.} =
+      for item in comb.results(p):
+        return # Something was found, means we don't match
+      yield (p, Void())
   )
 
 proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/utils.nim
+++ b/src/nort/utils.nim
@@ -38,3 +38,9 @@ macro merge*(a: typedesc[not tuple], b: typedesc[tuple]): typedesc =
 macro merge*(a: typedesc[tuple], b: typedesc[not tuple]): typedesc =
   ## Just returns `a` since we don't merge tuples with single types
   return a
+
+
+template yieldfrom*[T](iter: iterable[T]) =
+  ## Yields every remaining item in `iter`
+  for item in iter:
+    yield item

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -127,12 +127,6 @@ suite "ReDoS":
     let redos = +(+(e'a'))
     assert redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
 
-  test "Any amount of a's or optional a's"L
-    let redos = +((-e('a') | -(?e'a')))
-    check redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
-
-
-
 test "Can join unrelated types":
   let g = e('(') * digit()
   g.check {

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -5,6 +5,14 @@ import nort/base
 
 import ./utils
 
+test "Can match a character":
+  let g = dot()
+  g.check {
+    "a": 'a',
+    "b": 'b',
+    "cd": 'c'
+  }
+
 test "Can match digit":
   let g = digit()
   g.check {

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -119,6 +119,11 @@ test "Negation matches":
     "hello": false
   }
 
+test "ReDoS":
+  # If we didn't have lazy evaluation, this would fail to parse
+  let redos = +(+(e'a'))
+  echo redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
 test "Can join unrelated types":
   let g = e('(') * digit()
   g.check {

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -119,10 +119,19 @@ test "Negation matches":
     "hello": false
   }
 
-test "ReDoS":
-  # If we didn't have lazy evaluation, this would fail to parse
-  let redos = +(+(e'a'))
-  echo redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+suite "ReDoS":
+  # Series of grammars to test how we hold up against ReDoS attacks
+  # Lazy evaluation should help with most
+  test "Any amount of any amount of a's":
+    # If we didn't have lazy evaluation, this would fail to parse
+    let redos = +(+(e'a'))
+    assert redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
+
+  test "Any amount of a's or optional a's"L
+    let redos = +((-e('a') | -(?e'a')))
+    check redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
+
+
 
 test "Can join unrelated types":
   let g = e('(') * digit()


### PR DESCRIPTION
Implements #6 

This uses closure iterators for lazy evaluation of grammars. This helps with grammars that have lots of branching since we only materialise paths as we need them