### PR TITLE
Another cleanup

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,5 @@
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config
+switch("warningAsError", "IgnoredSymbolInjection:on")

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -201,6 +201,7 @@ proc `*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[R] =
   (left <*> right).map(it => it.right)
 
 
+# auto is used because `Combinator[merge(A, B)]` was giving a symbol injection warning
 proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): auto =
   ## Joins two combinators and merges the tuples together so that the return value
   ## is a tuple with the fields of `A` merged with `B` into a single tuple

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -200,8 +200,10 @@ proc `*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[R] =
   ## Joins two combinators but only retains the right value
   (left <*> right).map(it => it.right)
 
-proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combinator[merge(A, B)] =
-  ## Joins two combinators and merges the tuples together
+
+proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): auto =
+  ## Joins two combinators and merges the tuples together so that the return value
+  ## is a tuple with the fields of `A` merged with `B` into a single tuple
   runnableExamples:
     let g = any(e"won", e"lost")$outcome * e" " * digit()$score
 
@@ -209,8 +211,7 @@ proc `*`*[A: tuple, B: tuple](left: Combinator[A], right: Combinator[B]): Combin
     # The names were merged into a single tuple
     assert res.outcome == "won"
     assert res.score == 9
-
-  (left <*> right).map(values => join(values.left, values.right, type(merge(A, B))))
+  (left <*> right).map(values => join(values.left, values.right, merge(A, B)))
 
 proc `*`*[A: tuple, B: not tuple](left: Combinator[A], right: Combinator[B]): Combinator[A] =
   ## Joins two combinators. Only returns the left combinator so named values are carried through

--- a/src/nort/utils.nim
+++ b/src/nort/utils.nim
@@ -30,6 +30,7 @@ macro merge*(a: typedesc[tuple], b: typedesc[tuple]): typedesc =
 
   for child in b:
     result.add(nnkIdentDefs.newTree(ident child[0].strVal, child[1], newEmptyNode()))
+  echo result.treeREpr
 
 template merge*(a: typedesc[not tuple], b: typedesc[tuple]): typedesc =
   ## Just returns `b` since we don't merge tuples with single types

--- a/src/nort/utils.nim
+++ b/src/nort/utils.nim
@@ -31,13 +31,13 @@ macro merge*(a: typedesc[tuple], b: typedesc[tuple]): typedesc =
   for child in b:
     result.add(nnkIdentDefs.newTree(ident child[0].strVal, child[1], newEmptyNode()))
 
-macro merge*(a: typedesc[not tuple], b: typedesc[tuple]): typedesc =
+template merge*(a: typedesc[not tuple], b: typedesc[tuple]): typedesc =
   ## Just returns `b` since we don't merge tuples with single types
-  return b
+  b
 
-macro merge*(a: typedesc[tuple], b: typedesc[not tuple]): typedesc =
+template merge*(a: typedesc[tuple], b: typedesc[not tuple]): typedesc =
   ## Just returns `a` since we don't merge tuples with single types
-  return a
+  a
 
 
 template yieldfrom*[T](iter: iterable[T]) =

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -127,6 +127,19 @@ suite "ReDoS":
     let redos = +(+(e'a'))
     assert redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
 
+suite "Tuple type carrying":
+  test "Two tuples copy fields":
+    let g = e"hello"$left * e"world"$right
+    assert g is tuple[left: string, right: string]
+
+  test "Right tuple is carried over type":
+    let g = e"hello" * e"world"$right
+    assert g is tuple[right: string]
+
+  test "Left tuple is carried over type":
+    let g = e"hello"$left * e"world"
+    assert g is tuple[right: string]
+
 test "Can join unrelated types":
   let g = e('(') * digit()
   g.check {

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -130,15 +130,15 @@ suite "ReDoS":
 suite "Tuple type carrying":
   test "Two tuples copy fields":
     let g = e"hello"$left * e"world"$right
-    assert g is tuple[left: string, right: string]
+    assert g.T is tuple[left: string, right: string]
 
   test "Right tuple is carried over type":
     let g = e"hello" * e"world"$right
-    assert g is tuple[right: string]
+    assert g.T is tuple[right: string]
 
   test "Left tuple is carried over type":
     let g = e"hello"$left * e"world"
-    assert g is tuple[right: string]
+    assert g.T is tuple[left: string]
 
 test "Can join unrelated types":
   let g = e('(') * digit()


### PR DESCRIPTION
Turns the injection warning into an error and removes another instance I found.
Don't know why I need to use `auto` to get around this