### PR TITLE
Update `Void` join docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: nimble test
 
       - name: Test doc examples
-        run: nimble doc src/nort.nim
+        run: nimble doc --project src/nort.nim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim }}
+          use-nightlies: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update nimble

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Setup Nim Enviroment
         uses: actions/checkout@master
 
-      - uses: iffy/install-nim@v5
+      - uses: jiro4989/setup-nim-action@v2
         with:
-          version: ${{ matrix.nim }}
+          nim-version: ${{ matrix.nim }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update nimble
         run: nimble update

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -18,9 +18,6 @@ type
     ## Single parse result. This should return the remaining data to parse along with
     ## the value that was returned
 
-  ParseTree*[T] = seq[ParseResult[T]]
-    ## Tree of parsed result values
-
   Explorer*[T] = iterator (p: Parser): ParseResult[T] {.closure.}
     ## Iterator that returns all the paths a parser can take
 

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -186,9 +186,9 @@ proc `<*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[l
   ## The [*] series of operators are more user friendly by flattening the returned values
   return initCombinator(proc (): Explorer[tuple[left: L, right: R]] =
     iterator (parser: Parser): ParseResult[tuple[left: L, right: R]] {.closure.} =
-      for res in left.results(parser):
-        for (finalParser, rightValue) in right.results(res.parser):
-          yield (finalParser, (res.value, rightValue))
+      for (newParser, leftValue) in left.results(parser):
+        for (finalParser, rightValue) in right.results(newParser):
+          yield (finalParser, (leftValue, rightValue))
   )
 
 proc `<*`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -228,9 +228,9 @@ template `*`*[A, B](left: Combinator[A], right: Combinator[B]): Combinator[Void]
   -(left <*> right)
 
 proc `*`*(left: Combinator[Void], right: Combinator[Void]): Combinator[Void] =
-  ## Joins two combinators
+  ## Joins two combinators that have no types associated with them
   runnableExamples:
-    let g = e"hello" * e" " * e"world"
+    let g = -e"hello" * -e" " * -e"world"
     assert g.test("hello world")
 
   return -(left <*> right)

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -186,9 +186,9 @@ proc `<*>`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[tuple[l
   ## The [*] series of operators are more user friendly by flattening the returned values
   return initCombinator(proc (): Explorer[tuple[left: L, right: R]] =
     iterator (parser: Parser): ParseResult[tuple[left: L, right: R]] {.closure.} =
-      for (newParser, leftValue) in left.results(parser):
-        for (finalParser, rightValue) in right.results(newParser):
-          yield (finalParser, (leftValue, rightValue))
+      for res in left.results(parser):
+        for (finalParser, rightValue) in right.results(res.parser):
+          yield (finalParser, (res.value, rightValue))
   )
 
 proc `<*`*[L, R](left: Combinator[L], right: Combinator[R]): Combinator[L] =

--- a/src/nort/utils.nim
+++ b/src/nort/utils.nim
@@ -30,7 +30,6 @@ macro merge*(a: typedesc[tuple], b: typedesc[tuple]): typedesc =
 
   for child in b:
     result.add(nnkIdentDefs.newTree(ident child[0].strVal, child[1], newEmptyNode()))
-  echo result.treeREpr
 
 template merge*(a: typedesc[not tuple], b: typedesc[tuple]): typedesc =
   ## Just returns `b` since we don't merge tuples with single types


### PR DESCRIPTION
The example wasn't actually joining `Void` combinators