### PR TITLE
Fix too many recursive calls on long strings

### DIFF
--- a/nort.nimble
+++ b/nort.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.1"
+version       = "0.4.2"
 author        = "Jake Leahy"
 description   = "Type safe parser combinator"
 license       = "MIT"

--- a/nort.nimble
+++ b/nort.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.2"
+version       = "0.5.0"
 author        = "Jake Leahy"
 description   = "Type safe parser combinator"
 license       = "MIT"

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -88,7 +88,7 @@ proc `&`*(a, b: Void): Void = a
 proc match*[T](comb: Combinator[T], data: string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match.
   let p = Parser(data: data)
-  for res in (comb).results(p):
+  for res in comb.results(p):
     return res.value.some()
 
 proc test*[T](comb: Combinator[T], data: sink string): bool =

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -74,11 +74,6 @@ proc trace*[T](comb: Combinator[T]): Combinator[T] =
 # It helps with errors if the type system knows its a Combinator, compiler should inline it
 proc fin*(): Combinator[Void] {.inline.} =
   ## Expects there to be no more data
-  runnableExamples:
-    let g = e"hello" * fin()
-
-    assert g.test("hello")
-    assert not g.test("hello world")
 
   return initCombinator(proc (): Explorer[Void] =
     iterator (p: Parser): ParseResult[Void] {.closure.} =
@@ -92,9 +87,8 @@ proc `&`*(a, b: Void): Void = a
 
 proc match*[T](comb: Combinator[T], data: string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match.
-  ## This expects the whole string to match, use [anyAll] to get substring matching
   let p = Parser(data: data)
-  for res in (comb * fin()).results(p):
+  for res in (comb).results(p):
     return res.value.some()
 
 proc test*[T](comb: Combinator[T], data: sink string): bool =

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -1,4 +1,5 @@
 ## This is internal library code to set everything up
+## .. importdoc:: helpers.nim
 import std/[options, macros, strformat, sugar]
 export options
 
@@ -69,14 +70,31 @@ proc trace*[T](comb: Combinator[T]): Combinator[T] =
         echo "Failed to parse"
   )
 
+# You'll see functions like this that don't need to be functions.
+# It helps with errors if the type system knows its a Combinator, compiler should inline it
+proc fin*(): Combinator[Void] {.inline.} =
+  ## Expects there to be no more data
+  runnableExamples:
+    let g = e"hello" * fin()
+
+    assert g.test("hello")
+    assert not g.test("hello world")
+
+  return initCombinator(proc (): Explorer[Void] =
+    iterator (p: Parser): ParseResult[Void] {.closure.} =
+      if p.len == 0:
+        yield (p, Void())
+  )
+
 # Functions to make Void compose with Chain
 proc add*(coll: var Chain[Void], val: Void) = discard
 proc `&`*(a, b: Void): Void = a
 
 proc match*[T](comb: Combinator[T], data: string): Option[T] =
-  ## Checks if a string matches a pattern. Returns the first match
+  ## Checks if a string matches a pattern. Returns the first match.
+  ## This expects the whole string to match, use [anyAll] to get substring matching
   let p = Parser(data: data)
-  for res in comb.results(p):
+  for res in (comb * fin()).results(p):
     return res.value.some()
 
 proc test*[T](comb: Combinator[T], data: sink string): bool =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -332,8 +332,8 @@ proc `not`*(comb: Combinator): Combinator[Void] =
   )
 
 proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
-  ## Expects a combinator to match zero or more times, returns all matches.
-  ## This is non-greedy
+  ## Expects a combinator to match zero or more times. Returns all matches
+  ## This is greedy and tries to match the most
   runnableExamples:
     let g = *e"hey"
     assert g.test("")
@@ -342,14 +342,21 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   return initCombinator(proc (): Explorer[Chain[T]] =
     iterator (p: Parser): ParseResult[Chain[T]] {.closure.} =
       # Start with the no match base case
-      var frontier: Deque[ParseResult[Chain[T]]] = [(p, default(Chain[T]))].toDeque()
-      # Find longest match, building up the value and checkpoints
+      var
+        frontier: seq[ParseResult[Chain[T]]] = @[(p, default(Chain[T]))]
+        matches: seq[ParseResult[Chain[T]]] = @[]
+      # Do DFS to mimic the old recursive approach
       while frontier.len > 0:
-        let (curr, value) = frontier.popFirst()
-        yield (curr, value)
+        let (curr, value) = frontier.pop()
+        matches &= (curr, value)
         for match in comb.results(curr):
           let nextItem = (match.parser, value & match.value)
-          frontier.addLast(nextItem)
+          frontier &= nextItem
+
+      for i in countdown(matches.len - 1, 0):
+        yield matches[i]
+
+
   )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -348,10 +348,13 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
       # Do DFS to mimic the old recursive approach
       while frontier.len > 0:
         let (curr, value) = frontier.pop()
-        matches &= (curr, value)
         for match in comb.results(curr):
           let nextItem = (match.parser, value & match.value)
           frontier &= nextItem
+        # Everything matches itself.
+        # In the base case that nothing matches, it just means nothing else is added
+        # to the frontier so this is the last item
+        matches &= (curr, value)
 
       for i in countdown(matches.len - 1, 0):
         yield matches[i]

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -356,6 +356,7 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
         # to the frontier so this is the last item
         matches &= (curr, value)
 
+      # Yield backwards to mimic recursives FIFO
       for i in countdown(matches.len - 1, 0):
         yield matches[i]
 

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -374,8 +374,8 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
         if not found: break
 
       # Now work back, returning largest match and then slowing chopping off points
-      for parser in parsers:
-        yield (parser, items)
+      for i in countdown(parsers.len - 1, 0):
+        yield (parsers[i], items)
         when T isnot Void: # Void never grows
           if items.len > 0:
             items.setLen(items.len - 1)

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -1,4 +1,4 @@
-import std/[options, sugar, macros, sequtils, strutils, setutils, sets]
+import std/[options, sugar, macros, sequtils, strutils, setutils, sets, deques]
 
 export options
 
@@ -145,22 +145,6 @@ proc just*[T](comb: Combinator[T]): Combinator[T] =
       for res in comb.results(p):
         if res.parser.len == 0: # No input left
           yield res
-  )
-
-# You'll see functions like this that don't need to be functions.
-# It helps with errors if the type system knows its a Combinator, compiler should inline it
-proc fin*(): Combinator[Void] {.inline.} =
-  ## Expects there to be no more data
-  runnableExamples:
-    let g = e"hello" * fin()
-
-    assert g.test("hello")
-    assert not g.test("hello world")
-
-  return initCombinator(proc (): Explorer[Void] =
-    iterator (p: Parser): ParseResult[Void] {.closure.}=
-      if p.len == 0:
-        yield (p, Void())
   )
 
 proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
@@ -348,8 +332,8 @@ proc `not`*(comb: Combinator): Combinator[Void] =
   )
 
 proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
-  ## Expects a combinator to match zero or more times. Returns all matches
-  ## This is greedy and tries to match the most
+  ## Expects a combinator to match zero or more times, returns all matches.
+  ## This is non-greedy
   runnableExamples:
     let g = *e"hey"
     assert g.test("")
@@ -357,28 +341,15 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
 
   return initCombinator(proc (): Explorer[Chain[T]] =
     iterator (p: Parser): ParseResult[Chain[T]] {.closure.} =
-      # We can't use recursion or that would blow the stack.
-      # We instead find the longest length and then work backwards
-      var
-        items: Chain[T]
-        parsers: seq[Parser] = @[p]
-        pos = p
+      # Start with the no match base case
+      var frontier: Deque[ParseResult[Chain[T]]] = [(p, default(Chain[T]))].toDeque()
       # Find longest match, building up the value and checkpoints
-      while true:
-        var found = false
-        for (nextParser, value) in comb.results(pos):
-          pos = nextParser
-          items &= value
-          parsers &= pos
-          found = true
-        if not found: break
-
-      # Now work back, returning largest match and then slowing chopping off points
-      for i in countdown(parsers.len - 1, 0):
-        yield (parsers[i], items)
-        when T isnot Void: # Void never grows
-          if items.len > 0:
-            items.setLen(items.len - 1)
+      while frontier.len > 0:
+        let (curr, value) = frontier.popFirst()
+        yield (curr, value)
+        for match in comb.results(curr):
+          let nextItem = (match.parser, value & match.value)
+          frontier.addLast(nextItem)
   )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -355,8 +355,31 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
     assert g.test("")
     assert g.test("heyhey")
 
-  # The right recursion will make this find the longest match first
-  (comb <*> lazy(() => *comb)).map(values => values.left & values.right) | succeed(default(Chain[T]))
+  return initCombinator(proc (): Explorer[Chain[T]] =
+    iterator (p: Parser): ParseResult[Chain[T]] {.closure.} =
+      # We can't use recursion or that would blow the stack.
+      # We instead find the longest length and then work backwards
+      var
+        items: Chain[T]
+        parsers: seq[Parser] = @[p]
+        pos = p
+      # Find longest match, building up the value and checkpoints
+      while true:
+        var found = false
+        for (nextParser, value) in comb.results(pos):
+          pos = nextParser
+          items &= value
+          parsers &= pos
+          found = true
+        if not found: break
+
+      # Now work back, returning largest match and then slowing chopping off points
+      for parser in parsers:
+        yield (parser, items)
+        when T isnot Void: # Void never grows
+          if items.len > 0:
+            items.setLen(items.len - 1)
+  )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
   ## Expects a combinator to match 1 or more times. Returns all matches

--- a/src/nort/helpers.nim
+++ b/src/nort/helpers.nim
@@ -9,3 +9,6 @@ let
     ## Newline character. Is cross platform and handles both windows and linux line endings
 
   ws*: Combinator[Void] = -e(Whitespace)
+
+  anyAll*: Combinator[Void] = *(-dot())
+    ## Matches anything without returning any value. Use this to make your pattern a substring match

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -127,6 +127,10 @@ suite "ReDoS":
     let redos = +(+(e'a'))
     assert redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
 
+  test "Repition doesn't recurse":
+    let g = *e('a')
+    assert g.match("a".repeat(2000)).isSome()
+
 suite "Tuple type carrying":
   test "Two tuples copy fields":
     let g = e"hello"$left * e"world"$right

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -127,7 +127,7 @@ suite "ReDoS":
     let redos = +(+(e'a'))
     assert redos.match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").isSome()
 
-  test "Repition doesn't recurse":
+  test "Can parse long strings":
     let g = *e('a')
     assert g.match("a".repeat(2000)).isSome()
 

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -1,7 +1,7 @@
 import std/[unittest, strutils]
 
 import nort
-import nort/base
+import nort/[base, helpers]
 
 import ./utils
 
@@ -10,7 +10,6 @@ test "Can match a character":
   g.check {
     "a": 'a',
     "b": 'b',
-    "cd": 'c'
   }
 
 test "Can match digit":
@@ -25,14 +24,14 @@ test "Can match digit":
   }
 
 test "Can match string":
-  let g = e"hello"
+  let g = e"hello" * anyAll
   g.check {
     "hello": "hello",
     "helloworld": "hello"
   }
 
 test "Can parse until target":
-  let g = dot().until(e"hello")
+  let g = dot().until(e"hello") * -(?e"hello")
   g.check {
     "abcdhello": "abcd",
     "hello": "",
@@ -44,7 +43,10 @@ test "Can match * that are turned into strings":
   g.check {
     "": "",
     "ccc": "ccc",
-    "a": ""
+  }
+
+  g.check {
+    "b": false
   }
 
 test "* doesn't eat too much":
@@ -119,7 +121,7 @@ test "Can match union":
   discard val.get().bar
 
 test "Negation matches":
-  let g = not e"hello"
+  let g = (not e"hello") * anyAll
   g.check {
     "world": true,
     "hello": false

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -73,6 +73,12 @@ test "Can chain Void":
     "hello": true
   }
 
+test "* matches in right order":
+  let g = *dot() * e('d')
+  g.check {
+    "abcd": "abcd"
+  }
+
 test "Chain non strings":
   let g = +(digit() * -e',')
   g.check {

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -10,6 +10,7 @@ test "Can match a character":
   g.check {
     "a": 'a',
     "b": 'b',
+    "cd": 'c'
   }
 
 test "Can match digit":
@@ -24,14 +25,14 @@ test "Can match digit":
   }
 
 test "Can match string":
-  let g = e"hello" * anyAll
+  let g = e"hello"
   g.check {
     "hello": "hello",
     "helloworld": "hello"
   }
 
 test "Can parse until target":
-  let g = dot().until(e"hello") * -(?e"hello")
+  let g = dot().until(e"hello")
   g.check {
     "abcdhello": "abcd",
     "hello": "",
@@ -43,10 +44,7 @@ test "Can match * that are turned into strings":
   g.check {
     "": "",
     "ccc": "ccc",
-  }
-
-  g.check {
-    "b": false
+    "a": ""
   }
 
 test "* doesn't eat too much":
@@ -121,7 +119,7 @@ test "Can match union":
   discard val.get().bar
 
 test "Negation matches":
-  let g = (not e"hello") * anyAll
+  let g = not e"hello"
   g.check {
     "world": true,
     "hello": false


### PR DESCRIPTION
The `*` prefix was implemented with recursion which was causing "too many function call" errors on long strings. This implements it using iteration instead, still replicates the recursive approach I think so should be fine