### PR TITLE
Improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+nimble.develop
+nimble.paths
+nimbledeps

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nimble.develop
 nimble.paths
 nimbledeps
+htmldocs/

--- a/benchmark.nim
+++ b/benchmark.nim
@@ -7,7 +7,7 @@ timeIt "Parse a long string":
   doAssert g.match("a".repeat(8000)).isSome()
 
 timeIt "Parse a long string in bigger chunks":
-  let g = *e("a")
+  let g = *e("aaaaaaaaaa")
   doAssert g.match("a".repeat(8000)).isSome()
 
 timeIt "Parse a long string, ignoring everything":

--- a/benchmark.nim
+++ b/benchmark.nim
@@ -1,0 +1,15 @@
+import benchy
+import nort
+import std/strutils
+
+timeIt "Parse a long string":
+  let g = *e('a')
+  doAssert g.match("a".repeat(8000)).isSome()
+
+timeIt "Parse a long string in bigger chunks":
+  let g = *e("a")
+  doAssert g.match("a".repeat(8000)).isSome()
+
+timeIt "Parse a long string, ignoring everything":
+  let g = *dot()
+  doAssert g.match("a".repeat(8000)).isSome()

--- a/benchmark.nim
+++ b/benchmark.nim
@@ -1,6 +1,7 @@
 import benchy
 import nort
-import std/strutils
+import nort/helpers
+import std/[strutils, sugar]
 
 timeIt "Parse a long string":
   let g = *e('a')
@@ -13,3 +14,60 @@ timeIt "Parse a long string in bigger chunks":
 timeIt "Parse a long string, ignoring everything":
   let g = *dot()
   doAssert g.match("a".repeat(8000)).isSome()
+
+type
+  ReportLevel = enum
+    Hint
+    Info
+    Warning
+    Error
+
+let mismatchGrammar = block:
+  let
+    header = -e"Expression: " * -dot().untilIncl(nl)
+    expectedHeader = e"Expected one of (first mismatch at [position]):"
+    idx = between(digit()$position, e'[', e']')
+    mismatch = idx * ws * dot().until(nl)$decl
+    passedType: Combinator[string] = ws * -idx * -dot().untilIncl(e": ") * dot().untilIncl(nl)
+
+  -dot().untilIncl(header) * (*passedType)$passedTypes * -dot().untilIncl(expectedHeader) * *(nl * mismatch)$mismatches
+
+let errGrammar = block:
+  let
+    stacktraceHeader = e "stack trace: (most recent call last)\n"
+    position = e('(') * digit()$line * e", " * digit()$column * e')'
+    path = *(-(not (position | nl)) * dot())
+    errorLevel = expect(ReportLevel)
+    # Code name of the error/warning the compiler has internally e.g. [UndeclaredIdentifier].
+    # This always appears at the end
+    internalName = dot().until(e']').between(e'[', e']') * fin()
+    instantiation = dot().until(nl)
+    errorMsg = dot().until(internalName)$msg * ws * ?internalName$name
+    errorLine = errorLevel$level * e": " * errorMsg
+    msgLine = path$file * position * -(e' ') * any((error: errorLine, instantiation: instantiation * -nl))$info
+  # We need to track if the first line indicates its a stacktrace, this lets us
+  # catch if its a static exception
+  (?stacktraceHeader).map(it => it.isSome())$isException * ws * msgLine
+
+timeIt "Matching an actual grammar":
+  const msg = """
+  /tmp/test.nim(1, 17) Error: type mismatch
+  Expression: "hello" * "world"
+    [1] "hello": string
+    [2] "world": string
+
+  Expected one of (first mismatch at [position]):
+  [1] func `*`[T](x, y: set[T]): set[T]
+  [1] proc `*`(x, y: float): float
+  [1] proc `*`(x, y: float32): float32
+  [1] proc `*`(x, y: int): int
+  [1] proc `*`(x, y: int16): int16
+  [1] proc `*`(x, y: int32): int32
+  [1] proc `*`(x, y: int64): int64
+  [1] proc `*`(x, y: int8): int8
+  [1] proc `*`(x, y: uint): uint
+  [1] proc `*`(x, y: uint16): uint16
+  [1] proc `*`(x, y: uint32): uint32
+  [1] proc `*`(x, y: uint64): uint64
+  [1] proc `*`(x, y: uint8): uint8"""
+  doAssert errGrammar.match(msg).isSome()

--- a/nort.nimble
+++ b/nort.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.5.0"
+version       = "0.6.0"
 author        = "Jake Leahy"
 description   = "Type safe parser combinator"
 license       = "MIT"

--- a/nort.nimble
+++ b/nort.nimble
@@ -11,3 +11,5 @@ srcDir        = "src"
 
 requires "nim >= 2.2.4"
 requires "gh:ire4ever1190/casserole >= 0.2.0"
+feature "dev":
+ requires "benchy >= 0.1.0"

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -39,7 +39,7 @@ iterator results*[T](comb: Combinator[T], parser: Parser): ParseResult[T] =
   for item in iter(parser):
     yield item
 
-template initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
+proc initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
   ## Builds a combinator from an iterator
   Combinator[T](iter: factory)
 

--- a/src/nort/base.nim
+++ b/src/nort/base.nim
@@ -39,7 +39,7 @@ iterator results*[T](comb: Combinator[T], parser: Parser): ParseResult[T] =
   for item in iter(parser):
     yield item
 
-proc initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
+template initCombinator*[T](factory: proc (): Explorer[T]): Combinator[T] =
   ## Builds a combinator from an iterator
   Combinator[T](iter: factory)
 
@@ -62,7 +62,8 @@ proc trace*[T](comb: Combinator[T]): Combinator[T] =
       var foundSomething = false
       for path in comb.results(p):
         foundSomething = true
-        echo fmt"Parsed: '{p.data[p.pos ..< path.parser.pos]}'"
+
+        echo "Parsed: '", p.slice(p.pos ..< path.parser.pos), "'"
         when T isnot Void:
             echo fmt"Got: '{path.value}'"
         yield path
@@ -82,12 +83,12 @@ proc fin*(): Combinator[Void] {.inline.} =
   )
 
 # Functions to make Void compose with Chain
-proc add*(coll: var Chain[Void], val: Void) = discard
-proc `&`*(a, b: Void): Void = a
+template add*(coll: var Chain[Void], val: Void) = discard
+template `&`*(a, b: Void): Void = a
 
-proc match*[T](comb: Combinator[T], data: string): Option[T] =
+proc match*[T](comb: Combinator[T], data: sink string): Option[T] =
   ## Checks if a string matches a pattern. Returns the first match.
-  let p = Parser(data: data)
+  let p = initParser(data)
   for res in comb.results(p):
     return res.value.some()
 

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -342,24 +342,61 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
 
   return initCombinator(proc (): Explorer[Chain[T]] =
     iterator (p: Parser): ParseResult[Chain[T]] {.closure.} =
-      # Start with the no match base case
+      # We want to not materialise all the results ahead of time cause that would
+      # just create duplicate memory e.g. [a], [a, b], [a, b, c]
+      # This also creates slowdowns cause now each step needs to make a new list, copy, and add.
+      #
+      # We do this using a linked list sort of structure, where `tails` tells us two things
+      # - its index matches with `heads`
+      # - the parent (previous match) is at `tails[i]`
+      # So at any tails index, we know its value along with the value that came before.
+      # Yes we could use a tuple, but having two lists allows us to search it faster later
+
       var
-        frontier: seq[ParseResult[Chain[T]]] = @[(p, default(Chain[T]))]
-        matches: seq[ParseResult[Chain[T]]] = @[]
-      # Do DFS to mimic the old recursive approach
+        heads: seq[T] = @[] # Stores the matched values
+        tails: seq[int] = @[] # Store the previous index that came before this amtch
+        frontier: seq[tuple[parser: Parser, tailIdx: int]] = @[(p, -1)] # -1 means there is no value
+        matches: seq[tuple[parser: Parser, tailIdx: int]] = @[]
       while frontier.len > 0:
-        let (curr, value) = frontier.pop()
+        let (curr, tailIdx) = frontier.pop()
         for match in comb.results(curr):
-          let nextItem = (match.parser, value & match.value)
-          frontier &= nextItem
+          heads.add(match.value)
+          tails.add(tailIdx)
+          frontier.add((match.parser, heads.high))
         # Everything matches itself.
         # In the base case that nothing matches, it just means nothing else is added
         # to the frontier so this is the last item
-        matches &= (curr, value)
+        matches.add((curr, tailIdx))
 
-      # Yield backwards to mimic recursives FILO
-      for _ in 0 ..< matches.len:
-        yield matches.pop()
+      # Yield backwards to mimic recursives FILO. Materialise the linked list into
+      # a Chain[T] only when the result is actually consumed. Yes we have to rebuild it
+      # each step, but majority of the time the full list isn't even used
+      for i in countdown(matches.len - 1, 0):
+        let (parser, idx {.used.}) = matches[i]
+        when T is Void:
+          # Chain semantics for `Void` just make `Void`
+          # So we can skip materialising anything
+          yield (parser, Void())
+        else:
+          # First figure out how long the match was
+          let len = block:
+            var n = 0
+            var c = idx
+            while c >= 0:
+              inc n
+              c = tails[c]
+            n
+          var value = (when T is char: newStringUninit(len) else: newSeq[T](len))
+
+          # Now we work from the end of the matches, up the parents filling in the values
+          var c = idx
+          var pos = len - 1
+          while c >= 0:
+            value[pos] = heads[c]
+            # remember, tails stores the parent match
+            c = tails[c]
+            dec pos
+          yield (parser, value)
   )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -357,7 +357,7 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
         # to the frontier so this is the last item
         matches &= (curr, value)
 
-      # Yield backwards to mimic recursives FIFO
+      # Yield backwards to mimic recursives FILO
       for _ in 0 ..< matches.len:
         yield matches.pop()
   )

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -137,7 +137,7 @@ proc expect*(input: char): Combinator[char] =
     assert g.match("a") == some('a')
     assert g.match("b").isNone()
 
-  expect($input).map(it => it[0])
+  filter(dot(), it == input)
 
 proc expect*[T](values: HashSet[T]): Combinator[T] =
   ## Expects a single value from a set of values.
@@ -358,8 +358,8 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
         matches &= (curr, value)
 
       # Yield backwards to mimic recursives FIFO
-      for i in countdown(matches.len - 1, 0):
-        yield matches[i]
+      for _ in 0 ..< matches.len:
+        yield matches.pop()
   )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/combinators.nim
+++ b/src/nort/combinators.nim
@@ -50,7 +50,7 @@ proc join[R](a: tuple, b: tuple, ret: typedesc[R]): R =
 # Combinators
 #
 
-proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] =
+template filter*[T](comb: Combinator[T], check: untyped): Combinator[T] =
   ## Filter what values are allowed to consider that the filter has passed
   runnableExamples:
     import std/[strutils, sugar]
@@ -58,12 +58,27 @@ proc filter*[T](comb: Combinator[T], check: proc (val: T): bool): Combinator[T] 
     assert g.test("hello world")
     assert not g.test("world")
 
-  return initCombinator(proc (): Explorer[T] =
+  initCombinator(proc (): Explorer[T] =
     iterator (p: Parser): ParseResult[T] {.closure.} =
       for res in comb.results(p):
-        if check(res.value):
+        let it {.inject, cursor.} = res.value
+        if check:
           yield res
   )
+
+proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
+  ## Allows you to perform an operator on a combinators output if it passes
+  runnableExamples:
+    import std/[sugar, strutils]
+
+    let g = "hello".expect.map(toUpperAscii)
+    assert g.match("hello").get() == "HELLO"
+
+  return initCombinator(proc (): Explorer[R] =
+    iterator (p: Parser): ParseResult[R] {.closure.} =
+      for res in comb.results(p):
+        yield (res.parser, op(res.value))
+    )
 
 proc dot*(): Combinator[char] =
   ## Parses any character
@@ -94,22 +109,13 @@ proc epsilon(): Combinator[Void] =
   ## Matches the empty string and doesn't return any input
   return succeed(Void())
 
-proc expect*(input: char): Combinator[char] =
-  ## Expects a character to appear
-  runnableExamples:
-    let g = expect('a')
-    assert g.match("a") == some('a')
-    assert g.match("b").isNone()
-
-  return filter(dot(), it => it == input)
-
-proc expect*(expect: set[char]): Combinator[char] =
+template expect*(expect: set[char]): Combinator[char] =
   ## Expects a set of characters, returns the matched value
   runnableExamples:
     let g = expect({'a', 'b', 'c'})
     assert g.match("a") == some('a')
     assert g.match("d").isNone()
-  return filter(dot(), it => it in expect)
+  filter(dot(), it in expect)
 
 proc expect*(expect: string): Combinator[string] =
   ## Expects a certain string
@@ -123,6 +129,15 @@ proc expect*(expect: string): Combinator[string] =
       if Some(res) ?== p.continuesWith(expect):
         yield res
   )
+
+proc expect*(input: char): Combinator[char] =
+  ## Expects a character to appear
+  runnableExamples:
+    let g = expect('a')
+    assert g.match("a") == some('a')
+    assert g.match("b").isNone()
+
+  expect($input).map(it => it[0])
 
 proc expect*[T](values: HashSet[T]): Combinator[T] =
   ## Expects a single value from a set of values.
@@ -146,20 +161,6 @@ proc just*[T](comb: Combinator[T]): Combinator[T] =
         if res.parser.len == 0: # No input left
           yield res
   )
-
-proc map*[T, R](comb: Combinator[T], op: proc (inp: T): R): Combinator[R] =
-  ## Allows you to perform an operator on a combinators output if it passes
-  runnableExamples:
-    import std/[sugar, strutils]
-
-    let g = "hello".expect.map(toUpperAscii)
-    assert g.match("hello").get() == "HELLO"
-
-  return initCombinator(proc (): Explorer[R] =
-    iterator (p: Parser): ParseResult[R] {.closure.} =
-      for res in comb.results(p):
-        yield (res.parser, op(res.value))
-    )
 
 proc `-`*(comb: Combinator): Combinator[Void] =
   ## Erases the type from a combinator
@@ -359,8 +360,6 @@ proc `*`*[T](comb: Combinator[T]): Combinator[Chain[T]] =
       # Yield backwards to mimic recursives FIFO
       for i in countdown(matches.len - 1, 0):
         yield matches[i]
-
-
   )
 
 proc `+`*[T](comb: Combinator[T]): Combinator[Chain[T]] =

--- a/src/nort/helpers.nim
+++ b/src/nort/helpers.nim
@@ -8,7 +8,8 @@ let
   nl*: Combinator[Void] = ?e('\r') * e('\n')
     ## Newline character. Is cross platform and handles both windows and linux line endings
 
-  ws*: Combinator[Void] = -e(Whitespace)
+  ws*: Combinator[Void] = *(-e(Whitespace))
+    ## Matches any amount of whitespace
 
   anyAll*: Combinator[Void] = *(-dot())
     ## Matches anything without returning any value. Use this to make your pattern a substring match

--- a/src/nort/parser.nim
+++ b/src/nort/parser.nim
@@ -38,15 +38,17 @@ template peek*(p: Parser): Option[char] =
   if p.eof: none(char)
   else: some p.data[][p.pos]
 
-func skip*(p: sink Parser, n: int): Parser =
+template skip*(p: sink Parser, n: int): Parser =
   ## Skips the parser by `n` characters
   Parser(data: p.data, pos: p.pos + n)
 
-func eat*(p: sink Parser): Option[(Parser, char)] =
+template eat*(p: sink Parser): Option[(Parser, char)] =
   ## Attempts to grab the next character and return rest of data
   let v = p.peek()
   if v.isSome():
-    return some((p.skip(1), v.unsafeGet()))
+    some((p.skip(1), v.unsafeGet()))
+  else:
+    none((Parser, char))
 
 func continuesWith*(p: sink Parser, token: sink string): Option[(Parser, string)] =
   ## Checks if the parser continues with a string

--- a/src/nort/parser.nim
+++ b/src/nort/parser.nim
@@ -6,32 +6,47 @@ type
   Parser* = object
     ## Represents the base parser for stepping through a stream.
     ## Used to represent a slice without needing to copy everything
-    data*: string # TODO: Ensure this is copy-on-write or else we'll explode
-    pos*: int ## Current position inside `data`
+    data: ref string # done to ensure the string isn't copied
+    pos: int ## Current position inside `data`
+
+func initParser*(data: sink string): Parser =
+  ## Initialises a new parser
+  let payload = new string
+  payload[] = data
+  Parser(data: payload, pos: 0)
 
 func len*(p: Parser): int =
   ## Returns the length of remaining data
-  return p.data.len - p.pos
+  return p.data[].len - p.pos
 
 func eof*(p: Parser): bool =
   ## Checks if the parser is at the end of the data
   return p.len == 0
+
+func slice*(p: Parser, data: HSlice[int, int]): string =
+  ## Returns a slice of data. This is for debugging, should
+  ## not be used for actual parsing
+  return p.data[][data]
+
+func pos*(p: Parser): int =
+  ## Getter for the parsers current position
+  return p.pos
 
 func peek*(p: Parser): Option[char] =
   ## Returns next character (if not eof). Does not use input
   if p.eof: none(char)
   else: some p.data[p.pos]
 
-func skip*(p: Parser, n: int): Parser =
+func skip*(p: sink Parser, n: int): Parser =
   ## Skips the parser by `n` characters
   return Parser(data: p.data, pos: p.pos + n)
 
-func eat*(p: Parser): Option[(Parser, char)] =
+func eat*(p: sink Parser): Option[(Parser, char)] =
   ## Attempts to grab the next character and return rest of data
   p.peek().map(c => (p.skip(1), c))
 
-func continuesWith*(p: Parser, token: string): Option[(Parser, string)] =
+func continuesWith*(p: sink Parser, token: sink string): Option[(Parser, string)] =
   ## Checks if the parser continues with a string
-  let matched = p.data.skip(token, start = p.pos)
-  if matched == 0: none((Parser, string))
-  else: some((p.skip(matched), token))
+  let matched = p.data[].skip(token, p.pos) == 0
+  if matched: some((p.skip(token.len), token))
+  else: none((Parser, string))

--- a/src/nort/parser.nim
+++ b/src/nort/parser.nim
@@ -1,6 +1,7 @@
 ## Contains basic parsing code. This can be reused for writing your own combinators
 
 import std/[options, parseutils, sugar]
+import pkg/casserole
 
 type
   Parser* = object
@@ -15,38 +16,40 @@ func initParser*(data: sink string): Parser =
   payload[] = data
   Parser(data: payload, pos: 0)
 
-func len*(p: Parser): int =
+template len*(p: Parser): int =
   ## Returns the length of remaining data
-  return p.data[].len - p.pos
+  p.data[].len - p.pos
 
-func eof*(p: Parser): bool =
+template eof*(p: Parser): bool =
   ## Checks if the parser is at the end of the data
-  return p.len == 0
+  p.len == 0
 
 func slice*(p: Parser, data: HSlice[int, int]): string =
   ## Returns a slice of data. This is for debugging, should
   ## not be used for actual parsing
-  return p.data[][data]
+  p.data[][data]
 
-func pos*(p: Parser): int =
+template pos*(p: Parser): int =
   ## Getter for the parsers current position
-  return p.pos
+  p.pos
 
-func peek*(p: Parser): Option[char] =
+template peek*(p: Parser): Option[char] =
   ## Returns next character (if not eof). Does not use input
   if p.eof: none(char)
-  else: some p.data[p.pos]
+  else: some p.data[][p.pos]
 
 func skip*(p: sink Parser, n: int): Parser =
   ## Skips the parser by `n` characters
-  return Parser(data: p.data, pos: p.pos + n)
+  Parser(data: p.data, pos: p.pos + n)
 
 func eat*(p: sink Parser): Option[(Parser, char)] =
   ## Attempts to grab the next character and return rest of data
-  p.peek().map(c => (p.skip(1), c))
+  let v = p.peek()
+  if v.isSome():
+    return some((p.skip(1), v.unsafeGet()))
 
 func continuesWith*(p: sink Parser, token: sink string): Option[(Parser, string)] =
   ## Checks if the parser continues with a string
-  let matched = p.data[].skip(token, p.pos) == 0
+  let matched = p.data[].skip(token, p.pos) > 0
   if matched: some((p.skip(token.len), token))
   else: none((Parser, string))

--- a/tests/testAll.nim
+++ b/tests/testAll.nim
@@ -137,6 +137,10 @@ suite "ReDoS":
     let g = *e('a')
     assert g.match("a".repeat(2000)).isSome()
 
+  test "Multiple long string matches":
+    let g = *(dot() * nl)
+    assert g.match((" ".repeat(100) & "\n").repeat(100)).isSome()
+
 suite "Tuple type carrying":
   test "Two tuples copy fields":
     let g = e"hello"$left * e"world"$right

--- a/tests/testBase.nim
+++ b/tests/testBase.nim
@@ -1,0 +1,23 @@
+## Some basic checks on the base functions. Helps track problems faster
+
+import std/[unittest, strutils]
+
+import nort
+import nort/[base, helpers, parser]
+
+import ./utils
+
+suite "continuesWith":
+  let p = initParser("hello world")
+
+  test "It exists at the start":
+    check p.continuesWith("hello").isSome()
+
+  test "Doesn't exist at the start":
+    check p.continuesWith("world").isNone()
+
+  test "Can match something at the end":
+    check p.skip("hello ".len).continuesWith("world").isSome()
+
+  test "Doesn't match if no space left":
+    check p.skip("hello w".len).continuesWith("world").isNone()


### PR DESCRIPTION
Trying to improve the performance since `nimsight` gets cranky when I start parsing errors. 

Moving the string to a reference so it doesn't get copied improved performance by about 4x (155.445 ms to 4ms) on a terrible benchmark. Also made a lot more things inline, but that just shaved tiny bits off.

This also fixes long loops, we now only materialise an actual `*grammer` value when its requested. So the memory doesn't grow $O(n^2)$ like it did before

**Before**
```
   min time    avg time  std dv   runs name
  15.205 ms   15.990 ms  ±0.487   x312 Parse a long string
   2.794 ms    3.000 ms  ±0.126  x1000 Parse a long string in bigger chunks
  13.850 ms   14.704 ms  ±0.573   x339 Parse a long string, ignoring everything
   0.642 ms    0.698 ms  ±0.052  x1000 Matching an actual grammar
```

**After**
```
   min time    avg time  std dv   runs name
   1.101 ms    1.316 ms  ±0.189  x1000 Parse a long string
   0.126 ms    0.134 ms  ±0.021  x1000 Parse a long string in bigger chunks
   0.621 ms    0.669 ms  ±0.065  x1000 Parse a long string, ignoring everything
   0.543 ms    0.594 ms  ±0.063  x1000 Matching an actual grammar
```